### PR TITLE
Sl1mb0 syscall

### DIFF
--- a/src/event/system-call/open.c
+++ b/src/event/system-call/open.c
@@ -1,0 +1,42 @@
+/ *
+	license
+* /
+
+//! Definiton of wrapper to `perf_event_open()` system call. 
+//!
+//! `perf_event_open` returns a file descriptor that allows 
+//! measuring performance information. Each file descriptor 
+//! corresponds to one event that is being measured. The file
+//! descriptor is then used in subsequent system calls.
+//! 
+//! Events can be enabled/disabled by using either of:
+//!
+//! * `ioctl()`
+//! * `prctl()`
+//!
+//! Disabled events maintain their existence and count value 
+//! but they are not counted, nor do they generate overflows.
+//!
+//! Two types of events: counting and sampled. Counting events
+//! count the aggregate number of events that occur; and can
+//! gathered by calling `read()`. Sampling events periodically 
+//! write measurements to a buffer that can be accessed by 
+//! calling `mmap()`.
+
+#include "open.h"
+
+static long 
+perf_event_open(struct perf_event_attr *hw_event,
+		pid_t pid,
+		int cpu,
+		int group_fd,
+		unsigned long flags)
+{
+	int ret;
+	ret = syscall(__NR_perf_event_open,
+			hw_event,
+			cpu,
+			group_fd,
+			flags);
+	return ret;
+}

--- a/src/event/system-call/open.c
+++ b/src/event/system-call/open.c
@@ -14,7 +14,7 @@
 //! * `ioctl()`
 //! * `prctl()`
 //!
-//! Disabled events maintain their existence and count value 
+//! Disabled events maintain their existence and count values 
 //! but they are not counted, nor do they generate overflows.
 //!
 //! Two types of events: counting and sampled. Counting events

--- a/src/event/system-call/open.c
+++ b/src/event/system-call/open.c
@@ -34,7 +34,7 @@ perf_event_open(struct perf_event_attr *event,
 {
 	int ret;
 	ret = syscall(__NR_perf_event_open,
-			hw_event,
+			event,
 			cpu,
 			group_fd,
 			flags);

--- a/src/event/system-call/open.c
+++ b/src/event/system-call/open.c
@@ -26,7 +26,7 @@
 #include "open.h"
 
 static long 
-perf_event_open(struct perf_event_attr *hw_event,
+perf_event_open(struct perf_event_attr *event,
 		pid_t pid,
 		int cpu,
 		int group_fd,

--- a/src/event/system-call/open.h
+++ b/src/event/system-call/open.h
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 static long 
-perf_event_open(struct perf_event_attr *hw_event,
+perf_event_open(struct perf_event_attr *event,
 		pid_t pid,
 		int cpu,
 		int group_fd,

--- a/src/event/system-call/open.h
+++ b/src/event/system-call/open.h
@@ -1,0 +1,25 @@
+/ * 
+	license
+* /
+
+//! Prototype wrapper the `perf_event_open()` system-call.
+//!
+//! No wrapper is provided for `perf_event_open()`;
+//! necessitating use of `syscall()`.
+//! see Linux man-page NOTES for `perf_event_open()` for details.
+
+#ifndef OPEN_H
+#define OPEN_H
+
+#include <linux/perf_event.h>
+#include <linux/hw_breakpoint.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static long 
+perf_event_open(struct perf_event_attr *hw_event,
+		pid_t pid,
+		int cpu,
+		int group_fd,
+		unsigned long flags);
+#endif


### PR DESCRIPTION
I added a wrapper for the `perf_event_open` system call. We should have it in one file so that everyone else can use it when writing their C code for getting event information. 