### PR TITLE
test & test list CLI functionality

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,5 +28,7 @@ fn main() {
 
     perf_bindings
         .write_to_file(out_path.join("perf_event.rs"))
-        .expect("Unable to write perf_event bindings to ./src/bindings/perf_event.rs");
+        .expect(
+        "Unable to write perf_event bindings to ./src/bindings/perf_event.rs",
+    );
 }

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,5 @@ fn main() {
 
     perf_bindings
         .write_to_file(out_path.join("perf_event.rs"))
-        .expect(
-        "Unable to write perf_event bindings to ./src/bindings/perf_event.rs",
-    );
+        .expect("Unable to write perf_event bindings to ./src/bindings/perf_event.rs");
 }

--- a/src/event/constants.rs
+++ b/src/event/constants.rs
@@ -35,7 +35,7 @@ const fn iocw(nr: u32, sz: usize) -> u32 {
 /// User: read
 /// Kernel: write
 const fn iocr(nr: u32, sz: usize) -> u32 {
-    (_IOC_WRITE << _IOC_DIRSHIFT)
+    (_IOC_READ << _IOC_DIRSHIFT)
         | (_IO_TYPE << _IOC_TYPESHIFT)
         | (nr << _IOC_NRSHIFT)
         | ((sz as u32) << _IOC_SIZESHIFT)

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,27 +21,27 @@ use structopt::StructOpt;
 /// Define command line options.
 #[derive(Debug, StructOpt)]
 enum Opt {
-  #[structopt(
+    #[structopt(
         setting = structopt::clap::AppSettings::TrailingVarArg,
         setting = structopt::clap::AppSettings::AllowLeadingHyphen,
         name = "stat",
         about = "Collects hardware/software event counters"
     )]
-  Stat(StatOptions),
-  #[structopt(
+    Stat(StatOptions),
+    #[structopt(
         setting = structopt::clap::AppSettings::TrailingVarArg,
         setting = structopt::clap::AppSettings::AllowLeadingHyphen,
         name = "test",
         about = "Runs sanity tests"
     )]
-  Test(TestOptions),
+    Test(TestOptions),
 }
 
 fn main() {
-  let opt = Opt::from_args();
-  match opt {
-    Opt::Stat(x) => run_stat(&x),
-    Opt::Test(x) => run_test(&x),
-  }
-  perf_event_hello();
+    let opt = Opt::from_args();
+    match opt {
+        Opt::Stat(x) => run_stat(&x),
+        Opt::Test(x) => run_test(&x),
+    }
+    perf_event_hello();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@
 
 mod event;
 mod stat;
+mod test;
 mod utils;
 
 use event::*;
 use stat::*;
+use test::*;
 extern crate structopt;
 
 use structopt::StructOpt;
@@ -19,19 +21,27 @@ use structopt::StructOpt;
 /// Define command line options.
 #[derive(Debug, StructOpt)]
 enum Opt {
-    #[structopt(
+  #[structopt(
         setting = structopt::clap::AppSettings::TrailingVarArg,
         setting = structopt::clap::AppSettings::AllowLeadingHyphen,
         name = "stat",
         about = "Collects hardware/software event counters"
     )]
-    Stat(StatOptions),
+  Stat(StatOptions),
+  #[structopt(
+        setting = structopt::clap::AppSettings::TrailingVarArg,
+        setting = structopt::clap::AppSettings::AllowLeadingHyphen,
+        name = "test",
+        about = "Runs sanity tests"
+    )]
+  Test(TestOptions),
 }
 
 fn main() {
-    let opt = Opt::from_args();
-    match opt {
-        Opt::Stat(x) => run_stat(&x),
-    }
-    perf_event_hello();
+  let opt = Opt::from_args();
+  match opt {
+    Opt::Stat(x) => run_stat(&x),
+    Opt::Test(x) => run_test(&x),
+  }
+  perf_event_hello();
 }

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -1,4 +1,5 @@
 use crate::test::Test;
+use std::{thread, time};
 
 // TODO: Remove this (it's just for testing the tests)
 // TEST: This test always passes
@@ -25,5 +26,21 @@ pub fn test_always_fails() -> Test {
         name: "always_fails".to_string(),
         description: "This test always fails".to_string(),
         call: always_fails,
+    }
+}
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test passes after 1 second
+pub fn test_passes_after_1sec() -> Test {
+    fn passes_after_1sec() -> bool {
+        let one_second = time::Duration::from_secs(1);
+        thread::sleep(one_second);
+        true
+    }
+
+    Test {
+        name: "passes_after_1sec".to_string(),
+        description: "This test passes after 1 second".to_string(),
+        call: passes_after_1sec,
     }
 }

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -1,0 +1,29 @@
+use crate::test::Test;
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test always passes
+pub fn test_always_passes() -> Test {
+    fn always_passes() -> bool {
+        true
+    }
+
+    Test {
+        name: "always_passes".to_string(),
+        description: "This test always passes".to_string(),
+        call: always_passes,
+    }
+}
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test always fails
+pub fn test_always_fails() -> Test {
+    fn always_fails() -> bool {
+        false
+    }
+
+    Test {
+        name: "always_fails".to_string(),
+        description: "This test always fails".to_string(),
+        call: always_fails,
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,82 @@
+//! Test driver
+use crate::utils::ParseError;
+use std::str::FromStr;
+extern crate structopt;
+use structopt::StructOpt;
+pub mod basic;
+pub mod pfm;
+
+/// Test Struct
+pub struct Test {
+    pub name: String,
+    pub description: String,
+    pub call: fn() -> bool,
+}
+
+/// TestEvents
+#[derive(Debug)]
+pub enum TestEvent {
+    RunAll,
+    List,
+}
+
+/// Match on each supported event to parse from command line
+impl FromStr for TestEvent {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" => Ok(TestEvent::RunAll),
+            "list" => Ok(TestEvent::List),
+            _ => Err(ParseError::InvalidEvent),
+        }
+    }
+}
+
+/// Configuration settings for running test
+#[derive(Debug, StructOpt)]
+pub struct TestOptions {
+    #[structopt(short, long, help = "Event to collect", number_of_values = 1)]
+    pub event: Vec<TestEvent>,
+
+    // Allows multiple arguments to be passed, collects everything remaining on
+    // the command line
+    #[structopt(required = false, help = "Command to run")]
+    pub command: Vec<String>,
+}
+
+/// Gathers all tests and returns a Vec with them all
+pub fn make_tests() -> Vec<Test> {
+    let mut tests: Vec<Test> = Vec::new();
+
+    // from basic.rs
+    tests.push(basic::test_always_passes());
+    tests.push(basic::test_always_fails());
+
+    // from pfm.rs
+    tests.push(pfm::test_check_for_libpfm4());
+
+    return tests;
+}
+
+/// Runs all tests and outputs results to stdout
+pub fn run_all_tests() {
+    println!("Running Sanity Tests\n");
+    let tests: Vec<Test> = make_tests();
+    for (index, test) in tests.iter().enumerate() {
+        let result = (test.call)();
+        let result_text: String;
+        if result {
+            result_text = "Ok".to_string();
+        } else {
+            result_text = "\x1b[0;31mFAILED!\x1b[0m".to_string();
+        }
+        println!("{:<2}: {:<60} : {}", index, test.description, result_text);
+    }
+}
+
+/// Handles the running of the "test" command.
+pub fn run_test(options: &TestOptions) {
+    println!("event: {:#?}", options.event);
+    println!("command: {:#?}", options.command);
+    run_all_tests();
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -73,7 +73,7 @@ pub fn run_all_tests(tests: &Vec<Test>) {
         } else {
             result_text = "\x1b[0;31mFAILED!\x1b[0m".to_string();
         }
-        print!("{}\n", result_text);
+        println!("{}", result_text);
     }
 }
 

--- a/src/test/pfm.rs
+++ b/src/test/pfm.rs
@@ -1,0 +1,27 @@
+use crate::test::Test;
+use std::process::Command;
+
+// TEST: Check for presence of libpfm4
+pub fn test_check_for_libpfm4() -> Test {
+    // This uses the linux command "ldconfig" and returns
+    // based on whether or not the output contains "libpfm."
+    fn check_for_libpfm4() -> bool {
+        let output = Command::new("ldconfig")
+            .args(&["-p"])
+            .output()
+            .expect("Issue running command.");
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            if text.contains("libpfm") {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Test {
+        name: "has_libpfm4".to_string(),
+        description: "Checks for presence of libpfm4".to_string(),
+        call: check_for_libpfm4,
+    }
+}

--- a/src/test/pfm.rs
+++ b/src/test/pfm.rs
@@ -16,7 +16,7 @@ pub fn test_check_for_libpfm4() -> Test {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     Test {


### PR DESCRIPTION
**`perf test` CLI Stuff**
===
This adds `ruperf test` and `ruperf test list` to the CLI. This outputs the results of tests to stdout. I tried to keep this as close to the output of the real `perf test`, which was very simple, but of course we can embellish it as we see fit.

I'm not sure I love this approach-- I am not using, like, rust tests, but a `stuct Test` that has a `fn() -> bool` as a parameter. I could use rust tests, and then evaluate them with, like, cargo or something when a flag is given, but that may be a can of worms. 

I tried to make it pretty easy to add new tests. I have it set up so it loads `struct Test`s from a different file and then puts them in a `Vec`-- new tests can be made in their own files, then added to the `Vec` in the `make_tests()` function.

The test form `libpfm4` uses the linux command `ldconfig`, and the output is scanned. This worked correctly on a few linux machines of different distros I tried it on (I uninstalled and reinstalled libpfm and tested both times). It's gross to use `std::process::Command` for this, but honestly, I think it's the only good way. The real `perf` gets to cheat with a compiler flag (on the real `perf` on my computer, it was compiled out...)

In `run_test`, I just tried to keep the event Enum Briana had in `stat.rs`, but I know I'm probably not parsing the way she intended... @Boursler -- could you take a peek at that?

Also, please don't refrain from ripping any of this to shreds-- I'm totally a novice 😅 I would love to know everything I'm doing wrongly (or just gross-ly)!