### PR TITLE
Feat: test & test list CLI functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@
 
 mod event;
 mod stat;
+mod test;
 mod utils;
 
 use event::*;
 use stat::*;
+use test::*;
 extern crate structopt;
 
 use structopt::StructOpt;
@@ -26,12 +28,20 @@ enum Opt {
         about = "Collects hardware/software event counters"
     )]
     Stat(StatOptions),
+    #[structopt(
+        setting = structopt::clap::AppSettings::TrailingVarArg,
+        setting = structopt::clap::AppSettings::AllowLeadingHyphen,
+        name = "test",
+        about = "Runs sanity tests"
+    )]
+    Test(TestOptions),
 }
 
 fn main() {
     let opt = Opt::from_args();
     match opt {
         Opt::Stat(x) => run_stat(&x),
+        Opt::Test(x) => run_test(&x),
     }
     perf_event_hello();
 }

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -1,0 +1,46 @@
+use crate::test::Test;
+use std::{thread, time};
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test always passes
+pub fn test_always_passes() -> Test {
+    fn always_passes() -> bool {
+        true
+    }
+
+    Test {
+        name: "always_passes".to_string(),
+        description: "This test always passes".to_string(),
+        call: always_passes,
+    }
+}
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test always fails
+pub fn test_always_fails() -> Test {
+    fn always_fails() -> bool {
+        false
+    }
+
+    Test {
+        name: "always_fails".to_string(),
+        description: "This test always fails".to_string(),
+        call: always_fails,
+    }
+}
+
+// TODO: Remove this (it's just for testing the tests)
+// TEST: This test passes after 1 second
+pub fn test_passes_after_1sec() -> Test {
+    fn passes_after_1sec() -> bool {
+        let one_second = time::Duration::from_secs(1);
+        thread::sleep(one_second);
+        true
+    }
+
+    Test {
+        name: "passes_after_1sec".to_string(),
+        description: "This test passes after 1 second".to_string(),
+        call: passes_after_1sec,
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,103 @@
+//! Test driver
+use crate::utils::ParseError;
+use std::io::stdout;
+use std::io::Write;
+use std::str::FromStr;
+extern crate structopt;
+use structopt::StructOpt;
+pub mod basic;
+pub mod pfm;
+
+/// Test Struct
+pub struct Test {
+    pub name: String,
+    pub description: String,
+    pub call: fn() -> bool,
+}
+
+/// TestEvents
+#[derive(Debug)]
+pub enum TestEvent {
+    RunAll,
+    List,
+}
+
+/// Match on each supported event to parse from command line
+impl FromStr for TestEvent {
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" => Ok(TestEvent::RunAll),
+            "list" => Ok(TestEvent::List),
+            _ => Err(ParseError::InvalidEvent),
+        }
+    }
+}
+
+/// Configuration settings for running test
+#[derive(Debug, StructOpt)]
+pub struct TestOptions {
+    #[structopt(short, long, help = "Event to collect", number_of_values = 1)]
+    pub event: Vec<TestEvent>,
+
+    // Allows multiple arguments to be passed, collects everything remaining on
+    // the command line
+    #[structopt(required = false, help = "Command to run")]
+    pub command: Vec<String>,
+}
+
+/// Gathers all tests and returns a Vec with them all
+pub fn make_tests() -> Vec<Test> {
+    let mut tests: Vec<Test> = Vec::new();
+
+    // from basic.rs
+    tests.push(basic::test_always_passes());
+    tests.push(basic::test_always_fails());
+    tests.push(basic::test_passes_after_1sec());
+
+    // from pfm.rs
+    tests.push(pfm::test_check_for_libpfm4());
+
+    tests
+}
+
+/// Runs all tests and outputs results to stdout
+pub fn run_all_tests(tests: &Vec<Test>) {
+    for (index, test) in tests.iter().enumerate() {
+        print!("{:>2}: {:<60} : ", index, test.description);
+        stdout().flush().unwrap();
+        let result = (test.call)();
+        let result_text: String;
+        if result {
+            result_text = "Ok".to_string();
+        } else {
+            result_text = "\x1b[0;31mFAILED!\x1b[0m".to_string();
+        }
+        println!("{}", result_text);
+    }
+}
+
+/// Lists all tests and outputs results to stdout
+pub fn list_all_tests(tests: &Vec<Test>) {
+    for (index, test) in tests.iter().enumerate() {
+        println!("{:>2}: {:<60}", index, test.description);
+    }
+}
+
+/// Handles the running of the "test" command.
+pub fn run_test(options: &TestOptions) {
+    let tests = make_tests();
+    let mut events = Vec::new();
+    if options.command.is_empty() {
+        events.push(TestEvent::RunAll);
+    }
+    for command in &options.command {
+        events.push(TestEvent::from_str(command).unwrap());
+    }
+    for event in &events {
+        match event {
+            TestEvent::RunAll => run_all_tests(&tests),
+            TestEvent::List => list_all_tests(&tests),
+        }
+    }
+}

--- a/src/test/pfm.rs
+++ b/src/test/pfm.rs
@@ -1,0 +1,27 @@
+use crate::test::Test;
+use std::process::Command;
+
+// TEST: Check for presence of libpfm4
+pub fn test_check_for_libpfm4() -> Test {
+    // This uses the linux command "ldconfig" and returns
+    // based on whether or not the output contains "libpfm."
+    fn check_for_libpfm4() -> bool {
+        let output = Command::new("ldconfig")
+            .args(&["-p"])
+            .output()
+            .expect("Issue running command.");
+        if output.status.success() {
+            let text = String::from_utf8_lossy(&output.stdout);
+            if text.contains("libpfm") {
+                return true;
+            }
+        }
+        false
+    }
+
+    Test {
+        name: "has_libpfm4".to_string(),
+        description: "Checks for presence of libpfm4".to_string(),
+        call: check_for_libpfm4,
+    }
+}


### PR DESCRIPTION
This is a fixed version of my last flawed PR that adds `perf test`.

Recap: 
This adds `ruperf test` and `ruperf test list` to the CLI. This outputs the results of tests to `stdout`. I tried to keep this as close to the output of the real `perf test`, which was very simple, but of course we can embellish it as we see fit.

The test for `libpfm4` uses the linux command `ldconfig`, and the output is scanned.