### PR TITLE
`unsafe` migration

### DIFF
--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -1,4 +1,5 @@
 use crate::event::fd;
+use crate::event::sys::sys;
 use crate::event::utils::*;
 use crate::stat::StatEvent;
 
@@ -15,9 +16,9 @@ pub fn event_open(event: &StatEvent) -> Result<fd::perf_event_attr, EventErr> {
     match &event {
         StatEvent::Cycles => {
             let event_open = &mut fd::perf_event_attr {
-                type_: fd::perf_type_id_PERF_TYPE_HARDWARE,
+                type_: sys::perf_type_id_PERF_TYPE_HARDWARE,
                 size: std::mem::size_of::<fd::perf_event_attr>() as u32,
-                config: fd::perf_hw_id_PERF_COUNT_HW_CPU_CYCLES as u64,
+                config: sys::perf_hw_id_PERF_COUNT_HW_CPU_CYCLES as u64,
                 ..Default::default()
             };
             event_open.set_disabled(1);
@@ -40,7 +41,6 @@ impl Event {
     }
 
     /// Start the counter on an event
-
     pub fn start_counter(&self) -> Result<isize, SysErr> {
         match self.fd.enable() {
             Ok(_) => self.fd.read(),

--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -3,7 +3,7 @@
 //! and `ioctl()` system calls;
 //! and their raw file descriptors.
 use crate::event::sys::sys;
-use crate::event::sys::wrapper::{ioctl_wrap, read_wrap};
+use crate::event::sys::wrapper::read_wrap;
 use crate::event::utils::*;
 
 pub type perf_event_attr = sys::perf_event_attr;
@@ -30,8 +30,10 @@ impl FileDesc {
     /// Enable the performance counter
     /// associated with `fd`.
     pub fn enable(&self) -> Result<(), SysErr> {
-        if ioctl_wrap(self.0, sys::ENABLE, 0) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::ENABLE as u64, 0) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         Ok(())
     }
@@ -39,8 +41,10 @@ impl FileDesc {
     /// Disable the performance counter
     /// associated with `fd`.
     pub fn disable(&self) -> Result<(), SysErr> {
-        if ioctl_wrap(self.0, sys::DISABLE, 0) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::DISABLE as u64, 0) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         Ok(())
     }
@@ -59,16 +63,20 @@ impl FileDesc {
             return Err(SysErr::IoArg);
         }
         let arg: *const usize = &count;
-        if ioctl_wrap(self.0, sys::REFRESH, arg) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::REFRESH as u64, arg) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         Ok(())
     }
 
     /// Reset the performance counter to 0.
     pub fn reset(&self) -> Result<(), SysErr> {
-        if ioctl_wrap(self.0, sys::RESET, 0) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::RESET as u64, 0) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         Ok(())
     }
@@ -82,8 +90,10 @@ impl FileDesc {
     /// struct that is passed to `FileDesc::new()`.
     pub fn overflow_period(&self, interval: usize) -> Result<(), SysErr> {
         let arg: *const usize = &interval;
-        if ioctl_wrap(self.0, sys::PERIOD, arg) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::PERIOD as u64, arg) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         Ok(())
     }
@@ -107,8 +117,10 @@ impl FileDesc {
         // to location specified by arg.
         let mut ret: usize = 0;
         let arg: *mut usize = &mut ret;
-        if ioctl_wrap(self.0, sys::ID, arg) == -1 {
-            return Err(SysErr::IoFail);
+        unsafe {
+            if libc::ioctl(self.0, sys::ID as u64, arg) == -1 {
+                return Err(SysErr::IoFail);
+            }
         }
         if ret == 0 {
             return Err(SysErr::IoId);

--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -51,14 +51,14 @@ impl FileDesc {
     /// the counter for the event associated
     /// with `fd` overflows. When the counter
     /// reaches 0, the event is disabled.
-    pub fn refresh(&self, count: u64) -> Result<(), SysErr> {
+    pub fn refresh(&self, count: usize) -> Result<(), SysErr> {
         // passing an argument of 0
         // along with `sys::REFRESH`
         // introduces undefined behavior.
         if count == 0 {
             return Err(SysErr::IoArg);
         }
-        let arg: *const u64 = &count;
+        let arg: *const usize = &count;
         if ioctl_wrap(self.0, sys::REFRESH, arg) == -1 {
             return Err(SysErr::IoFail);
         }
@@ -80,8 +80,8 @@ impl FileDesc {
     /// NOTE: The `__bindgen_anon_1` and `sample_type` fields
     /// must be initialized for the `perf_event_attr`
     /// struct that is passed to `FileDesc::new()`.
-    pub fn overflow_period(&self, interval: u64) -> Result<(), SysErr> {
-        let arg: *const u64 = &interval;
+    pub fn overflow_period(&self, interval: usize) -> Result<(), SysErr> {
+        let arg: *const usize = &interval;
         if ioctl_wrap(self.0, sys::PERIOD, arg) == -1 {
             return Err(SysErr::IoFail);
         }
@@ -102,11 +102,11 @@ impl FileDesc {
 
     /// Return event ID value
     /// associated with `fd`.
-    pub fn id(&self) -> Result<u64, SysErr> {
+    pub fn id(&self) -> Result<usize, SysErr> {
         // Write event id value
         // to location specified by arg.
-        let mut ret: u64 = 0;
-        let arg: *mut u64 = &mut ret;
+        let mut ret: usize = 0;
+        let arg: *mut usize = &mut ret;
         if ioctl_wrap(self.0, sys::ID, arg) == -1 {
             return Err(SysErr::IoFail);
         }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -15,33 +15,3 @@ mod utils;
 pub fn perf_event_hello() {
     println!("hello from your friendly perf_event file");
 }
-
-#[cfg(test)]
-#[test]
-fn wrapper_test() {
-    let sample_struct = fd::perf_event_attr__bindgen_ty_1 { sample_period: 1 };
-    let event = &mut fd::perf_event_attr {
-        type_: fd::perf_type_id_PERF_TYPE_HARDWARE,
-        size: std::mem::size_of::<fd::perf_event_attr>() as u32,
-        config: fd::perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS as u64,
-        __bindgen_anon_1: sample_struct,
-        sample_type: fd::perf_event_sample_format_PERF_SAMPLE_IP,
-        ..Default::default()
-    };
-    event.set_disabled(1);
-    event.set_exclude_kernel(1);
-    event.set_exclude_hv(1);
-    // Panic on failure.
-    let fd = fd::FileDesc::new(event, 0, -1, -1);
-    // Make sure ioctls are working.
-    fd.reset().unwrap();
-    fd.disable().unwrap();
-    fd.enable().unwrap();
-    let cnt: isize = fd.read().unwrap();
-    fd.id().unwrap();
-    // change overflow sampling period
-    fd.overflow_period(2).unwrap();
-    fd.refresh(3).unwrap();
-    assert_ne!(cnt, 0);
-    assert!(cnt > 0, "cnt = {}", cnt);
-}

--- a/src/event/sys/mod.rs
+++ b/src/event/sys/mod.rs
@@ -19,7 +19,9 @@ fn read_test() {
     event.set_exclude_hv(1);
     let fd: isize;
     fd = sys::perf_event_open(&event, 0, -1, -1, 0);
-    wrapper::ioctl_wrap(fd as i32, sys::ENABLE, 0);
+    unsafe {
+        libc::ioctl(fd as i32, sys::ENABLE as u64, 0);
+    }
     let cnt = wrapper::read_wrap(fd as i32);
     assert_ne!(cnt, 0);
     assert!(cnt > 0, "cnt = {}", cnt);

--- a/src/event/sys/mod.rs
+++ b/src/event/sys/mod.rs
@@ -1,2 +1,26 @@
+//! This module and it's sub-modules
+//! serve as a sort of 'dungeon'
+//! where all the unsafe code goes.
 pub mod sys;
 pub mod wrapper;
+
+#[cfg(test)]
+#[test]
+fn read_test() {
+    let event = &mut sys::perf_event_attr {
+        type_: sys::perf_type_id_PERF_TYPE_HARDWARE,
+        size: std::mem::size_of::<sys::perf_event_attr>() as u32,
+        // something to consider fixing. For now leave alone.
+        config: sys::perf_hw_id_PERF_COUNT_HW_CPU_CYCLES as u64,
+        ..Default::default()
+    };
+    event.set_disabled(1);
+    event.set_exclude_kernel(1);
+    event.set_exclude_hv(1);
+    let fd: isize;
+    fd = sys::perf_event_open(&event, 0, -1, -1, 0);
+    wrapper::ioctl_wrap(fd as i32, sys::ENABLE, 0);
+    let cnt = wrapper::read_wrap(fd as i32);
+    assert_ne!(cnt, 0);
+    assert!(cnt > 0, "cnt = {}", cnt);
+}

--- a/src/event/sys/wrapper.rs
+++ b/src/event/sys/wrapper.rs
@@ -11,8 +11,3 @@ pub fn read_wrap(fd: i32) -> isize {
     }
     count
 }
-
-// A generally generic system call.
-pub fn ioctl_wrap<T>(fd: i32, command: u32, arg: T) -> i32 {
-    unsafe { libc::ioctl(fd, command as u64, arg) }
-}

--- a/src/event/sys/wrapper.rs
+++ b/src/event/sys/wrapper.rs
@@ -1,11 +1,18 @@
-extern crate libc;
-use libc::{c_void, read};
+//! Non-perf related system call wrappers.
 
 pub fn read_wrap(fd: i32) -> isize {
+    //read treats each counter as virtualized u64
     let mut count: isize = 0;
     unsafe {
+        //buf must be *mut lbc::c_void type, mimics void pointer
+        //package count into buf so it is easy to read
         let buf: *mut libc::c_void = &mut count as *mut _ as *mut libc::c_void;
-        read(fd, buf, std::mem::size_of_val(&count));
+        libc::read(fd, buf, std::mem::size_of_val(&count));
     }
     count
+}
+
+// A generally generic system call.
+pub fn ioctl_wrap<T>(fd: i32, command: u32, arg: T) -> i32 {
+    unsafe { libc::ioctl(fd, command as u64, arg) }
 }


### PR DESCRIPTION
- [x] All unsafe code is now located in the `sys` module.
- [x] Unit-tests have been moved to where appropriate.
- [x] `cargo fmt` and `cargo test` pass.
- [ ]  `cargo clippy` passes with warnings. Most of the code that pisses off Mr. Clippy is in `src/bindings/perf_event.rs`, however, there is some code we've written that they do not like either. We should try to address this in a separate PR.