### PR TITLE
Fix PR 59

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 debug/
 target/
 # Remove Cargo.lock if building executable. Leave for libraries.
-# Cargo.lock
-**/*.rs

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,0 +1,8 @@
+#![allow(unknown_lints)]
+#![allow(clippy::all)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!("./perf_event.rs");


### PR DESCRIPTION
Fix PR 59 by adding missed mod.rs file that was ignored by .gitignore. Also update .gitignore to no longer blanket ignore nested .rs files.