### PR TITLE
Demonstrated program call in Stat

### DIFF
--- a/src/stat.rs
+++ b/src/stat.rs
@@ -41,33 +41,36 @@ pub struct StatOptions {
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
 
-    for event in &options.event {
-        let e = Event::new(*event);
-        let cnt: isize = e.start_counter().unwrap();
+    for command in &options.command {
 
-        //create another process from command
-        let output = Command::new(options.command.get(0).unwrap())
-            .output()
-            .expect("failed to execute process");
+        for event in &options.event {
+            let e = Event::new(*event);
+            let cnt: isize = e.start_counter().unwrap();
 
-        let final_cnt = e.stop_counter().unwrap();
-        let total_cnt = final_cnt - cnt;
+            //create another process from command
+            let output = Command::new(command)
+                .output()
+                .expect("failed to execute process");
 
-        // Create buffer variable
-        let buf = &output.stdout;
+            let final_cnt = e.stop_counter().unwrap();
+            let total_cnt = final_cnt - cnt;
 
-        // Convert &vec[u8] into string
-        let s = match str::from_utf8(buf) {
-            Ok(v) => v,
-            Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-        };
+            // Create buffer variable
+            let buf = &output.stdout;
 
-        //output command's output
-        println!(
-            "{}\nPerformance counter stats for '{}'\n",
-            s.to_string(),
-            options.command.get(0).unwrap()
-        );
-        println!(" Number of cycles: {}\n", total_cnt);
+            // Convert &vec[u8] into string
+            let s = match str::from_utf8(buf) {
+                Ok(v) => v,
+                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+            };
+
+            //output command's output
+            println!(
+                "{}\nPerformance counter stats for '{}'\n",
+                s.to_string(),
+                options.command.get(0).unwrap()
+            );
+            println!(" Number of cycles: {}\n", total_cnt);
+        }
     }
 }


### PR DESCRIPTION
**Added functionality for calling a command program and displaying output.**


I removed code involving `additions` because I believed it was for testing. if not, I'm happy to change this PR to include it!

I've used it on simple programs that need no arguments of their own such as: `date` and `ls` and `make`.

While commands like `echo "hello"` were not parsed correctly.

If `stat` only requires one program as a command, I can see a way of fixing this issue.