### PR TITLE
Instructions

### DIFF
--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -28,7 +28,7 @@ impl FileDesc {
         let ret: i32;
         ret = perf_event_open(event, pid as pid_t, cpu, group_fd, 0) as i32;
         if ret == -1 {
-            panic!("Panic: system call perf_event_open() failed in PerfEventFd::new()");
+            panic!("Panic: system call perf_event_open() failed in FileDesc::new()");
         }
         Self(ret)
     }
@@ -61,14 +61,14 @@ impl FileDesc {
     /// the counter for the event associated
     /// with `fd` overflows. When the counter
     /// reaches 0, the event is disabled.
-    pub fn refresh(&self, count: u64) -> Result<(), SysErr> {
+    pub fn refresh(&self, count: usize) -> Result<(), SysErr> {
         let ret: i32;
         // passing an argument of 0
         // with this ioctl is undefined behavior.
         if count == 0 {
             return Err(SysErr::IoArg);
         }
-        let arg: *const u64 = &count;
+        let arg: *const usize = &count;
         ret = unsafe { libc::ioctl(self.0, REFRESH as u64, arg) };
         if ret == -1 {
             return Err(SysErr::IoFail);
@@ -87,15 +87,12 @@ impl FileDesc {
     }
 
     /// Set the overflow period.
-    /// The interval argument to the
-    /// `ioctl()` must be a pointer to
-    /// an unsigned 64-bit integer.
     /// NOTE: The `__bindgen_anon_1` and `sample_type` fields
     /// must be initialized for the `perf_event_attr`
     /// struct that is passed to `FileDesc::new()`.
-    pub fn overflow_period(&self, interval: u64) -> Result<(), SysErr> {
+    pub fn overflow_period(&self, interval: usize) -> Result<(), SysErr> {
         let ret: i32;
-        let arg: *const u64 = &interval;
+        let arg: *const usize = &interval;
         ret = unsafe { libc::ioctl(self.0, PERIOD as u64, arg) };
         if ret == -1 {
             return Err(SysErr::IoFail);
@@ -117,11 +114,11 @@ impl FileDesc {
 
     /// Return event ID value
     /// associated with `fd`.
-    pub fn id(&self) -> Result<u64, SysErr> {
+    pub fn id(&self) -> Result<usize, SysErr> {
         // forgive me father.
-        let mut ret: u64 = 0;
+        let mut ret: usize = 0;
         ret = unsafe {
-            let result: *mut u64 = &mut ret;
+            let result: *mut usize = &mut ret;
             if libc::ioctl(self.0, ID as u64, result) == -1 {
                 return Err(SysErr::IoFail);
             }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -1,3 +1,10 @@
+//! An `Event` abstracts away
+//! initializing `perf_event_attr` 
+//! structs for arbitrary events;
+//! and the need to use `FileDesc` methods 
+//! for interacting with `perf_event` 
+//! related file descriptors.
+
 use crate::bindings::*;
 use crate::event::fd;
 use crate::event::utils::*;
@@ -41,6 +48,7 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
         _ => Err(EventErr::InvalidEvent),
     }
 }
+
 impl Event {
     /// Construct a new event
     pub fn new(event: StatEvent) -> Self {
@@ -50,7 +58,6 @@ impl Event {
     }
 
     /// Start the counter on an event
-
     pub fn start_counter(&self) -> Result<isize, SysErr> {
         match self.fd.enable() {
             Ok(_) => self.fd.read(),

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -25,19 +25,19 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_kernel(1);
             event_open.set_exclude_hv(1);
             Ok(*event_open)
-        },
-		StatEvent::Instructions => {
-			let event_open = &mut perf_event_attr {
-				type_: perf_type_id_PERF_TYPE_HARDWARE,
-				size: std::mem::size_of::<perf_event_attr>() as u32,
-				config: perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS as u64,
-				..Default::default()
-			};
-			event_open.set_disabled(1);
-			event_open.set_exclude_kernel(1);
-			event_open.set_exclude_hv(1);
-			Ok(*event_open)
-		},
+        }
+        StatEvent::Instructions => {
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HARDWARE,
+                size: std::mem::size_of::<perf_event_attr>() as u32,
+                config: perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS as u64,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
         _ => Err(EventErr::InvalidEvent),
     }
 }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -25,7 +25,19 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_kernel(1);
             event_open.set_exclude_hv(1);
             Ok(*event_open)
-        }
+        },
+		StatEvent::Instructions => {
+			let event_open = &mut perf_event_attr {
+				type_: perf_type_id_PERF_TYPE_HARDWARE,
+				size: std::mem::size_of::<perf_event_attr>() as u32,
+				config: perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS as u64,
+				..Default::default()
+			};
+			event_open.set_disabled(1);
+			event_open.set_exclude_kernel(1);
+			event_open.set_exclude_hv(1);
+			Ok(*event_open)
+		},
         _ => Err(EventErr::InvalidEvent),
     }
 }
@@ -57,8 +69,19 @@ impl Event {
 
 #[cfg(test)]
 #[test]
-fn event_open_test() {
+fn cycles_open_test() {
     let event = Event::new(StatEvent::Cycles);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn inst_open_test() {
+    let event = Event::new(StatEvent::Instructions);
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, 0);
     assert_ne!(cnt, -1);


### PR DESCRIPTION
I added support for counting hardware instructions to src/event/open.rs since I noticed that we have StatEvent::Instructions, but there was no support for it in event_open(). It is also important to note that when attempting to make skid constant, FileDesc::new() panics, which means perf_event_open() failed. This is obvious in hindsight since skid is the amount of instructions that execute between when an event happens, and when the kernel records the event. Hardware can't make skid constant when it's counting hardware instructions, and I'm guessing it's because it would have a huge effect on lots of other things.

I also changed the sensitve `u64` values in `fd.rs` to `usize`, and the panic message in `FileDesc::new()`.