### PR TITLE
Program call suggested changes

### DIFF
--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -24,9 +24,18 @@ impl FileDesc {
     /// Set up performance monitoring for
     /// configured event without any flags.
     /// Panics if `perf_event_open()` fails.
-    pub fn new(event: &mut perf_event_attr, pid: i32, cpu: i32, group_fd: i32) -> Self {
+    pub fn new(
+        event: &mut perf_event_attr,
+        child: Option<&std::process::Child>,
+        cpu: i32,
+        group_fd: i32,
+    ) -> Self {
         let ret: i32;
-        ret = perf_event_open(event, pid as pid_t, cpu, group_fd, 0) as i32;
+        let pid = match child {
+            Some(x) => x.id() as pid_t,
+            None => 0 as pid_t,
+        };
+        ret = perf_event_open(event, pid, cpu, group_fd, 0) as i32;
         if ret == -1 {
             panic!("Panic: system call perf_event_open() failed in PerfEventFd::new()");
         }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -31,9 +31,9 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
 }
 impl Event {
     /// Construct a new event
-    pub fn new(event: StatEvent) -> Self {
+    pub fn new(event: StatEvent, child: Option<&std::process::Child>) -> Self {
         let e: &mut perf_event_attr = &mut event_open(&event).unwrap();
-        let fd = fd::FileDesc::new(e, 0, -1, -1);
+        let fd = fd::FileDesc::new(e, child, -1, -1);
         Self { fd, event }
     }
 

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -26,6 +26,16 @@ impl FromStr for StatEvent {
     }
 }
 
+/// Match on each supported event to parse from command line
+impl ToString for StatEvent {
+    fn to_string(&self) -> String {
+        match self {
+            StatEvent::Cycles => "cycles".to_string(),
+            StatEvent::Instructions => "instructions".to_string(),
+        }
+    }
+}
+
 /// Configuration settings for running stat
 #[derive(Debug, StructOpt)]
 pub struct StatOptions {
@@ -41,31 +51,47 @@ pub struct StatOptions {
 /// Run perf stat on the given command and event combinations. Currently starts and stops a cycles timer in serial for each event specified.
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
+    struct EventCounter {
+        event: Event,
+        start: isize,
+        stop: isize,
+    }
 
-    for command in &options.command {
-        for event in &options.event {
-            let mut child = Command::new(&options.command[0])
-                .args(&options.command[1..])
-                .spawn()
-                .unwrap();
-            //prevent race condition on child program run time
-            unsafe { kill(child.id() as i32, libc::SIGSTOP) };
-            let e = Event::new(*event, Some(&child));
-            let cnt: isize = e.start_counter().unwrap();
-            unsafe { kill(child.id() as i32, libc::SIGCONT) };
+    let mut event_list: Vec<EventCounter> = Vec::new();
+    let mut child = Command::new(&options.command[0])
+        .args(&options.command[1..])
+        .spawn()
+        .unwrap();
+    //prevent race condition on child program run time on most programs
+    unsafe { kill(child.id() as i32, libc::SIGSTOP) };
+    for event in &options.event {
+        let e = Event::new(*event, Some(&child));
+        let start = e.start_counter().unwrap();
+        event_list.push(EventCounter {
+            event: e,
+            start: start,
+            stop: 0,
+        });
+    }
+    unsafe { kill(child.id() as i32, libc::SIGCONT) };
 
-            //create another process from command
-            child.wait().expect("Failed to execute process");
+    //create another process from command
+    child.wait().expect("Failed to execute process");
 
-            let final_cnt = e.stop_counter().unwrap();
-            let total_cnt = final_cnt - cnt;
+    for e in event_list.iter_mut() {
+        e.stop = e.event.stop_counter().unwrap();
+    }
 
-            //output command's output
-            println!(
-                "Performance counter stats for '{}'\n",
-                options.command.get(0).unwrap()
-            );
-            println!(" Number of cycles: {}\n", total_cnt);
-        }
+    //output command's output
+    println!(
+        "Performance counter stats for '{}'\n",
+        options.command.get(0).unwrap()
+    );
+    for event in event_list {
+        println!(
+            " Number of {}: {}\n",
+            event.event.event.to_string(),
+            event.stop - event.start
+        );
     }
 }

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -42,32 +42,20 @@ pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
 
     for command in &options.command {
-
         for event in &options.event {
-            let e = Event::new(*event);
+            let mut child = Command::new(command).spawn().unwrap();
+            let e = Event::new(*event, Some(&child));
             let cnt: isize = e.start_counter().unwrap();
 
             //create another process from command
-            let output = Command::new(command)
-                .output()
-                .expect("failed to execute process");
+            child.wait().expect("Failed to execute process");
 
             let final_cnt = e.stop_counter().unwrap();
             let total_cnt = final_cnt - cnt;
 
-            // Create buffer variable
-            let buf = &output.stdout;
-
-            // Convert &vec[u8] into string
-            let s = match str::from_utf8(buf) {
-                Ok(v) => v,
-                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-            };
-
             //output command's output
             println!(
-                "{}\nPerformance counter stats for '{}'\n",
-                s.to_string(),
+                "Performance counter stats for '{}'\n",
                 options.command.get(0).unwrap()
             );
             println!(" Number of cycles: {}\n", total_cnt);

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -41,33 +41,36 @@ pub struct StatOptions {
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
 
-    for event in &options.event {
-        let e = Event::new(*event);
-        let cnt: isize = e.start_counter().unwrap();
+    for command in &options.command {
 
-        //create another process from command
-        let output = Command::new(options.command.get(0).unwrap())
-            .output()
-            .expect("failed to execute process");
+        for event in &options.event {
+            let e = Event::new(*event);
+            let cnt: isize = e.start_counter().unwrap();
 
-        let final_cnt = e.stop_counter().unwrap();
-        let total_cnt = final_cnt - cnt;
+            //create another process from command
+            let output = Command::new(command)
+                .output()
+                .expect("failed to execute process");
 
-        // Create buffer variable
-        let buf = &output.stdout;
+            let final_cnt = e.stop_counter().unwrap();
+            let total_cnt = final_cnt - cnt;
 
-        // Convert &vec[u8] into string
-        let s = match str::from_utf8(buf) {
-            Ok(v) => v,
-            Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-        };
+            // Create buffer variable
+            let buf = &output.stdout;
 
-        //output command's output
-        println!(
-            "{}\nPerformance counter stats for '{}'\n",
-            s.to_string(),
-            options.command.get(0).unwrap()
-        );
-        println!(" Number of cycles: {}\n", total_cnt);
+            // Convert &vec[u8] into string
+            let s = match str::from_utf8(buf) {
+                Ok(v) => v,
+                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+            };
+
+            //output command's output
+            println!(
+                "{}\nPerformance counter stats for '{}'\n",
+                s.to_string(),
+                options.command.get(0).unwrap()
+            );
+            println!(" Number of cycles: {}\n", total_cnt);
+        }
     }
 }


### PR DESCRIPTION
Changes: add support for program arguments, follow child pid instead of parent pid so we profile the passed-in program, avoid race condition when spawned child completes before counter setup is complete, reorg stat.rs so that it sets up each timer individually while child is SIGSTOPPED (and thus not being followed/profiled so counter not counting against), then stop each counter after child is finished with wait. This rather than running program once per passed in event. Also implement to_string for events.

Ideas to improve:
- make wrapper module around process::Command so that system specific `kill` can be done in that wrapper module in some `sys` folder. Not doing it for now to gather people's input on the general solution.
Thanks everyone :)