### PR TITLE
Feat: perf test `--json` flag

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -15,6 +15,7 @@ pub struct Test {
 }
 
 /// TestResult
+#[derive(Clone)]
 pub enum TestResult {
     Passed,
     Failed(String),
@@ -28,8 +29,17 @@ pub struct TestOptions {
     #[structopt(short = "v", long = "verbose", help = "provide additional output")]
     pub verbose: bool,
 
-    #[structopt(short = "l", long = "list", help = "list runnable tests")]
+    // Should list runnable tests instead of performing them
+    #[structopt(
+        short = "l",
+        long = "list",
+        help = "list runnable tests instead of running"
+    )]
     pub should_list: bool,
+
+    // Should format output as json
+    #[structopt(short = "j", long = "json", help = "format output as json")]
+    pub json: bool,
 
     // A comma-seperated list of tests to skip
     #[structopt(
@@ -52,6 +62,7 @@ pub struct TestOptions {
 
 pub struct RunSettings {
     pub verbose: bool,
+    pub json: bool,
 }
 
 /// Handles the running of the "test" command.
@@ -69,6 +80,7 @@ pub fn run_test(options: &TestOptions) {
     }
     let settings = RunSettings {
         verbose: options.verbose,
+        json: options.json,
     };
     if !options.to_run.is_empty() {
         to_skip = (0..tests.len()).map(|x| x.to_string()).collect();

--- a/src/test/testutils.rs
+++ b/src/test/testutils.rs
@@ -3,6 +3,8 @@ use crate::test::pfm;
 use crate::test::RunSettings;
 use crate::test::Test;
 use crate::test::TestResult;
+use serde_json::json;
+use serde_json::to_string_pretty;
 use std::io::stdout;
 use std::io::Write;
 /// Gathers all tests and returns a Vec with them all
@@ -20,9 +22,48 @@ pub fn make_tests() -> Vec<Test> {
 /// Runs all tests and outputs results to stdout
 pub fn run_all_tests(tests: &[Test], to_skip: &[String], settings: &RunSettings) {
     let mut should_skip;
+    let mut tests_passed = 0;
+    let mut tests_failed = 0;
+    let mut tests_skipped = 0;
+    let mut results_as_json: Vec<serde_json::Value> = Vec::new();
+    if settings.json {}
     for (index, test) in tests.iter().enumerate() {
         should_skip = to_skip.iter().any(|i| *i == index.to_string());
-        run_single_test(&test, index, should_skip, "".to_string(), &settings);
+        let result = run_single_test(&test, index, should_skip, "".to_string(), &settings);
+        if settings.json {
+            let result_string: String;
+            match result {
+                TestResult::Passed => {
+                    tests_passed += 1;
+                    result_string = String::from("passed");
+                }
+                TestResult::Failed(_) => {
+                    tests_failed += 1;
+                    result_string = String::from("failed");
+                }
+                TestResult::Skipped => {
+                    tests_skipped += 1;
+                    result_string = String::from("skipped");
+                }
+            }
+            results_as_json.push(json!({
+                "name": test.name,
+                "description": test.description,
+                "result": result_string,
+                "number": index as u32
+            }));
+        }
+    }
+    if settings.json {
+        let result_object = json!({
+            "tests_available": results_as_json.len(),
+            "tests_ran": results_as_json.len() - tests_skipped,
+            "tests_passed": tests_passed,
+            "tests_failed": tests_failed,
+            "tests_skipped": tests_skipped,
+            "results": results_as_json,
+        });
+        println!("{}", to_string_pretty(&result_object).unwrap());
     }
 }
 
@@ -34,21 +75,24 @@ pub fn run_single_test(
     parent_index_string: String,
     settings: &RunSettings,
 ) -> TestResult {
-    print!(
-        "{:>2}{}: {:<60} : ",
-        parent_index_string, index, test.description
-    );
-    stdout().flush().unwrap();
+    if !settings.json {
+        print!(
+            "{:>2}{}: {:<60} : ",
+            parent_index_string, index, test.description
+        );
+        stdout().flush().unwrap();
+    }
     let result_type: TestResult;
     if should_skip {
         result_type = TestResult::Skipped;
     } else if test.subtests.is_empty() {
         result_type = (test.call)(&settings);
     } else {
-        println!();
+        if !settings.json {
+            println!();
+        }
         let mut overall_result_type: TestResult = TestResult::Passed;
         for (i, subtest) in test.subtests.iter().enumerate() {
-            // TODO: change false to a given subtest skip
             let result = run_single_test(subtest, i, false, index.to_string() + ".", settings);
             if let TestResult::Failed(_) = result {
                 overall_result_type = TestResult::Failed(String::new());
@@ -57,12 +101,14 @@ pub fn run_single_test(
         result_type = overall_result_type;
         return result_type;
     }
-    let result_text: String = match &result_type {
-        TestResult::Skipped => "\x1b[0;33mSkip\x1b[0m".to_string(),
-        TestResult::Passed => "Ok".to_string(),
-        TestResult::Failed(s) => format!("\x1b[0;31mFAILED!\x1b[0m {}", s),
-    };
-    println!("{}", result_text);
+    if !settings.json {
+        let result_text: String = match &result_type {
+            TestResult::Skipped => "\x1b[0;33mSkip\x1b[0m".to_string(),
+            TestResult::Passed => "Ok".to_string(),
+            TestResult::Failed(s) => format!("\x1b[0;31mFAILED!\x1b[0m {}", s),
+        };
+        println!("{}", result_text);
+    }
     result_type
 }
 


### PR DESCRIPTION
This flag, when passed to the program like `perf test --json`, will print results and stats as a valid JSON file to stdout, which can then be `>`-ed into a file like `perf test --json > out.json`. We already had `serde_json` as a dep, and it was super easy to add this feature, so I figured what the heck. 

I think `>`-ing to a file is better than handling a file and is a little more unix-y, but I can actually write to a file if anyone _really_ wants.