### PR TITLE
Feat: Call a program avoiding race condition on counters and child execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2.97"
 serde = {version ="1.0", features = ["derive"]}
 serde_json = "1.0"
 iced = "0.3.0"
+os_pipe = "0.9.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"

--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -24,9 +24,18 @@ impl FileDesc {
     /// Set up performance monitoring for
     /// configured event without any flags.
     /// Panics if `perf_event_open()` fails.
-    pub fn new(event: &mut perf_event_attr, pid: i32, cpu: i32, group_fd: i32) -> Self {
+    pub fn new(
+        event: &mut perf_event_attr,
+        child: Option<&std::process::Child>,
+        cpu: i32,
+        group_fd: i32,
+    ) -> Self {
         let ret: i32;
-        ret = perf_event_open(event, pid as pid_t, cpu, group_fd, 0) as i32;
+        let pid = match child {
+            Some(x) => x.id() as pid_t,
+            None => 0 as pid_t,
+        };
+        ret = perf_event_open(event, pid, cpu, group_fd, 0) as i32;
         if ret == -1 {
             panic!("Panic: system call perf_event_open() failed in FileDesc::new()");
         }

--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -24,18 +24,13 @@ impl FileDesc {
     /// Set up performance monitoring for
     /// configured event without any flags.
     /// Panics if `perf_event_open()` fails.
-    pub fn new(
-        event: &mut perf_event_attr,
-        child: Option<&std::process::Child>,
-        cpu: i32,
-        group_fd: i32,
-    ) -> Self {
+    pub fn new(event: &mut perf_event_attr, pid: Option<u32>, cpu: i32, group_fd: i32) -> Self {
         let ret: i32;
-        let pid = match child {
-            Some(x) => x.id() as pid_t,
+        let pid = match pid {
+            Some(x) => x as pid_t,
             None => 0 as pid_t,
         };
-        ret = perf_event_open(event, pid, cpu, group_fd, 0) as i32;
+        ret = perf_event_open(event, pid as pid_t, cpu, group_fd, 0) as i32;
         if ret == -1 {
             panic!("Panic: system call perf_event_open() failed in FileDesc::new()");
         }

--- a/src/event/fd.rs
+++ b/src/event/fd.rs
@@ -24,11 +24,11 @@ impl FileDesc {
     /// Set up performance monitoring for
     /// configured event without any flags.
     /// Panics if `perf_event_open()` fails.
-    pub fn new(event: &mut perf_event_attr, pid: Option<u32>, cpu: i32, group_fd: i32) -> Self {
+    pub fn new(event: &mut perf_event_attr, pid: Option<i32>, cpu: i32, group_fd: i32) -> Self {
         let ret: i32;
         let pid = match pid {
             Some(x) => x as pid_t,
-            None => 0 as pid_t,
+            None => 0_i32,
         };
         ret = perf_event_open(event, pid as pid_t, cpu, group_fd, 0) as i32;
         if ret == -1 {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -29,7 +29,7 @@ fn wrapper_test() {
     event.set_exclude_kernel(1);
     event.set_exclude_hv(1);
     // Panic on failure.
-    let fd = fd::FileDesc::new(event, 0, -1, -1);
+    let fd = fd::FileDesc::new(event, Some(0), -1, -1);
     // Make sure ioctls are working.
     fd.reset().unwrap();
     fd.disable().unwrap();

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -51,9 +51,9 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
 
 impl Event {
     /// Construct a new event
-    pub fn new(event: StatEvent) -> Self {
+    pub fn new(event: StatEvent, child: Option<&std::process::Child>) -> Self {
         let e: &mut perf_event_attr = &mut event_open(&event).unwrap();
-        let fd = fd::FileDesc::new(e, 0, -1, -1);
+        let fd = fd::FileDesc::new(e, child, -1, -1);
         Self { fd, event }
     }
 

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -51,7 +51,7 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
 
 impl Event {
     /// Construct a new event
-    pub fn new(event: StatEvent, pid: Option<u32>) -> Self {
+    pub fn new(event: StatEvent, pid: Option<i32>) -> Self {
         let e: &mut perf_event_attr = &mut event_open(&event).unwrap();
         let fd = fd::FileDesc::new(e, pid, -1, -1);
         Self { fd, event }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -1,8 +1,8 @@
 //! An `Event` abstracts away
-//! initializing `perf_event_attr` 
+//! initializing `perf_event_attr`
 //! structs for arbitrary events;
-//! and the need to use `FileDesc` methods 
-//! for interacting with `perf_event` 
+//! and the need to use `FileDesc` methods
+//! for interacting with `perf_event`
 //! related file descriptors.
 
 use crate::bindings::*;
@@ -77,7 +77,7 @@ impl Event {
 #[cfg(test)]
 #[test]
 fn cycles_open_test() {
-    let event = Event::new(StatEvent::Cycles);
+    let event = Event::new(StatEvent::Cycles, None);
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, 0);
     assert_ne!(cnt, -1);
@@ -88,7 +88,7 @@ fn cycles_open_test() {
 
 #[test]
 fn inst_open_test() {
-    let event = Event::new(StatEvent::Instructions);
+    let event = Event::new(StatEvent::Instructions, None);
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, 0);
     assert_ne!(cnt, -1);

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -51,9 +51,9 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
 
 impl Event {
     /// Construct a new event
-    pub fn new(event: StatEvent, child: Option<&std::process::Child>) -> Self {
+    pub fn new(event: StatEvent, pid: Option<u32>) -> Self {
         let e: &mut perf_event_attr = &mut event_open(&event).unwrap();
-        let fd = fd::FileDesc::new(e, child, -1, -1);
+        let fd = fd::FileDesc::new(e, pid, -1, -1);
         Self { fd, event }
     }
 

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -26,6 +26,16 @@ impl FromStr for StatEvent {
     }
 }
 
+/// Match on each supported event to parse from command line
+impl ToString for StatEvent {
+    fn to_string(&self) -> String {
+        match self {
+            StatEvent::Cycles => "cycles".to_string(),
+            StatEvent::Instructions => "instructions".to_string(),
+        }
+    }
+}
+
 /// Configuration settings for running stat
 #[derive(Debug, StructOpt)]
 pub struct StatOptions {
@@ -41,31 +51,47 @@ pub struct StatOptions {
 /// Run perf stat on the given command and event combinations. Currently starts and stops a cycles timer in serial for each event specified.
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
+    struct EventCounter {
+        event: Event,
+        start: isize,
+        stop: isize,
+    }
 
-    for command in &options.command {
-        for event in &options.event {
-            let mut child = Command::new(&options.command[0])
-                .args(&options.command[1..])
-                .spawn()
-                .unwrap();
-            //prevent race condition on child program run time
-            unsafe { kill(child.id() as i32, libc::SIGSTOP) };
-            let e = Event::new(*event, Some(&child));
-            let cnt: isize = e.start_counter().unwrap();
-            unsafe { kill(child.id() as i32, libc::SIGCONT) };
+    let mut event_list: Vec<EventCounter> = Vec::new();
+    let mut child = Command::new(&options.command[0])
+        .args(&options.command[1..])
+        .spawn()
+        .unwrap();
+    //prevent race condition on child program run time on most programs
+    unsafe { kill(child.id() as i32, libc::SIGSTOP) };
+    for event in &options.event {
+        let e = Event::new(*event, Some(&child));
+        let start = e.start_counter().unwrap();
+        event_list.push(EventCounter {
+            event: e,
+            start: start,
+            stop: 0,
+        });
+    }
+    unsafe { kill(child.id() as i32, libc::SIGCONT) };
 
-            //create another process from command
-            child.wait().expect("Failed to execute process");
+    //create another process from command
+    child.wait().expect("Failed to execute process");
 
-            let final_cnt = e.stop_counter().unwrap();
-            let total_cnt = final_cnt - cnt;
+    for e in event_list.iter_mut() {
+        e.stop = e.event.stop_counter().unwrap();
+    }
 
-            //output command's output
-            println!(
-                "Performance counter stats for '{}'\n",
-                options.command.get(0).unwrap()
-            );
-            println!(" Number of cycles: {}\n", total_cnt);
-        }
+    //output command's output
+    println!(
+        "Performance counter stats for '{}'\n",
+        options.command.get(0).unwrap()
+    );
+    for event in event_list {
+        println!(
+            " Number of {}: {}\n",
+            event.event.event.to_string(),
+            event.stop - event.start
+        );
     }
 }

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -42,32 +42,20 @@ pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
 
     for command in &options.command {
-
         for event in &options.event {
-            let e = Event::new(*event);
+            let mut child = Command::new(command).spawn().unwrap();
+            let e = Event::new(*event, Some(&child));
             let cnt: isize = e.start_counter().unwrap();
 
             //create another process from command
-            let output = Command::new(command)
-                .output()
-                .expect("failed to execute process");
+            child.wait().expect("Failed to execute process");
 
             let final_cnt = e.stop_counter().unwrap();
             let total_cnt = final_cnt - cnt;
 
-            // Create buffer variable
-            let buf = &output.stdout;
-
-            // Convert &vec[u8] into string
-            let s = match str::from_utf8(buf) {
-                Ok(v) => v,
-                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-            };
-
             //output command's output
             println!(
-                "{}\nPerformance counter stats for '{}'\n",
-                s.to_string(),
+                "Performance counter stats for '{}'\n",
                 options.command.get(0).unwrap()
             );
             println!(" Number of cycles: {}\n", total_cnt);

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -3,12 +3,10 @@ use crate::event::open::*;
 use crate::utils::ParseError;
 use std::str::{self, FromStr};
 extern crate structopt;
-use std::convert::TryInto;
-use std::io::{self, Read, Write};
+use os_pipe::pipe;
+use std::io::prelude::*;
 use std::os::unix::process::CommandExt;
-use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::thread;
+use std::process::Command;
 use structopt::StructOpt;
 
 /// Supported events
@@ -52,71 +50,33 @@ pub struct StatOptions {
     pub command: Vec<String>,
 }
 
-fn create_launch_thread(
+fn launch_command_process(
     command: Vec<String>,
-    pid_pipe: Stdio,
-    //    pid_sender: SyncSender<u32>,
-    // ack_receiver: Receiver<u32>
-) -> thread::JoinHandle<io::Result<Child>> {
-    thread::spawn(move || create_work_load(command.to_owned(), pid_pipe))
-}
-fn create_work_load(
-    command: Vec<String>,
-    pid_pipe: Stdio,
-    // pid_sender: SyncSender<u32>,
-    // ack_receiver: Receiver<u32>,
-) -> io::Result<Child> {
-    unsafe {
-        Command::new(&command[0])
-            .args(&command[1..])
-            .stdout(pid_pipe)
-            //pre_exec is blocking!
-            .pre_exec(move || work_load())
-            .spawn()
+    mut child_reader: os_pipe::PipeReader,
+    mut child_writer: os_pipe::PipeWriter,
+) -> i32 {
+    match unsafe { libc::fork() as i32 } {
+        0 => {
+            //set up command to execute and initialize read buffer
+            let mut buf = [0];
+            let mut comm = Command::new(&command[0]);
+            comm.args(&command[1..]);
+
+            // Tell parent program child is set up to execute
+            child_writer.write_all(&[1]).unwrap();
+            drop(child_writer);
+
+            //hear from parent that counters are set up
+            let nread = child_reader.read(&mut buf).unwrap();
+            assert_eq!(nread, 1);
+
+            let e = comm.exec();
+            panic!("child command failed: {}", e);
+        }
+        pid_child => pid_child,
     }
 }
-fn work_load(// command: Vec<String>,
-    //pid_sender: SyncSender<u32>,
-    // ack_receiver: Receiver<u32>,
-) -> io::Result<()> {
-    io::stdout()
-        .write_all(&std::process::id().to_ne_bytes())
-        .expect("Failed to write to pipe");
-    //original attempt to send mpsc and then execvp. Of course execvp just takes over the process, would need to pair it with fork. And mpsc doesn't seem to communicate between processes
 
-    // pid_sender
-    //    .send(std::process::id())
-    //   .expect("interthread communication failure");
-    // if ack_receiver
-    //     .recv()
-    //     .expect("Failed interthread communication")
-    //     == 0
-    {
-        // let c_s = std::ffi::CString::new(command[0].as_str()).unwrap();
-        // let f_ptr = c_s.as_bytes().as_ptr() as *const i8;
-        // let a_s: Vec<_> = command[1..]
-        //     .iter()
-        //     .map(|arg| std::ffi::CString::new(arg.as_str()).unwrap())
-        //     .collect();
-        // let mut a_ptr: Vec<_> = a_s.iter().map(|arg| arg.as_ptr()).collect();
-        // a_ptr.push(std::ptr::null());
-        // let p: *const *const std::os::raw::c_char = a_ptr.as_ptr();
-        // unsafe { libc::execvp(f_ptr, p) };
-
-        //sometimes I just need to waste some time
-        // let mut sum = 0;
-        // for i in 0..1000000 {
-        //     if i % 2 == 0 {
-        //         sum += i;
-        //     } else {
-        //         sum -= i;
-        //     }
-        // }
-        // println!("Sum {}\n", sum);
-    }
-    // std::thread::sleep(std::time::Duration::from_millis(10000));
-    Ok(())
-}
 /// Run perf stat on the given command and event combinations. Currently starts and stops a cycles timer in serial for each event specified.
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
@@ -127,20 +87,13 @@ pub fn run_stat(options: &StatOptions) {
     }
 
     let mut event_list: Vec<EventCounter> = Vec::new();
-    //mpsc route didn't work, they don't seem to communicate across processes
-    let (pid_sender, pid_receiver) = sync_channel::<u32>(0);
-    let (ack_sender, ack_receiver) = sync_channel::<u32>(0);
 
-    //this pipe attempt aso not working, no support for reading from child that I can find
-    let pid_pipe = Stdio::piped();
-    println!("My id: {}\n", std::process::id());
-    let mut child = create_launch_thread(options.command.clone(), pid_pipe);
+    let (reader, mut writer) = pipe().unwrap();
+    let (mut parent_reader, parent_writer) = pipe().unwrap();
 
-    let mut pid_arr: [u8; std::mem::size_of::<u32>()];
-    let pid_child = pid_pipe.read_exact(&pid_arr); // pid_receiver
-                                                   // .recv()
-                                                   // .expect("Failed interthread communication");
-    println!("My id: {}, Spawned Id {}\n", std::process::id(), pid_child);
+    let child_reader = reader.try_clone().unwrap();
+    let child_writer = parent_writer.try_clone().unwrap();
+    let pid_child = launch_command_process(options.command.clone(), child_reader, child_writer);
 
     for event in &options.event {
         event_list.push(EventCounter {
@@ -149,22 +102,25 @@ pub fn run_stat(options: &StatOptions) {
             stop: 0,
         });
     }
-    println!("Events Initialized\n");
-    // ack_sender
-    //     .send(0)
-    //     .expect("Failed interthread communication");
+
+    // Wait for child to say it is set up to execute
+    let mut buf = [0];
+    let nread = parent_reader.read(&mut buf).unwrap();
+    assert_eq!(nread, 1);
+
     for e in event_list.iter_mut() {
         e.start = e.event.start_counter().unwrap();
     }
-    println!("Counters Started, waiting for child completion\n");
 
-    //wait for thread and process
-    child
-        .join()
-        .expect("Failed to wait for thread")
-        .expect("Failed to wait for process")
-        .wait()
-        .expect("Faild to wait for process\n");
+    // Notify child counters are set up
+    writer.write_all(&[1]).unwrap();
+    drop(writer);
+
+    //wait for process to exit
+    let mut status: libc::c_int = 0;
+    let result = unsafe { libc::waitpid(pid_child, (&mut status) as *mut libc::c_int, 0) };
+    assert_eq!(result, pid_child);
+    assert_eq!(status, 0);
 
     for e in event_list.iter_mut() {
         e.stop = e.event.stop_counter().unwrap();

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -3,8 +3,12 @@ use crate::event::open::*;
 use crate::utils::ParseError;
 use std::str::{self, FromStr};
 extern crate structopt;
-use libc::kill;
-use std::process::Command;
+use std::convert::TryInto;
+use std::io::{self, Read, Write};
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::thread;
 use structopt::StructOpt;
 
 /// Supported events
@@ -48,6 +52,71 @@ pub struct StatOptions {
     pub command: Vec<String>,
 }
 
+fn create_launch_thread(
+    command: Vec<String>,
+    pid_pipe: Stdio,
+    //    pid_sender: SyncSender<u32>,
+    // ack_receiver: Receiver<u32>
+) -> thread::JoinHandle<io::Result<Child>> {
+    thread::spawn(move || create_work_load(command.to_owned(), pid_pipe))
+}
+fn create_work_load(
+    command: Vec<String>,
+    pid_pipe: Stdio,
+    // pid_sender: SyncSender<u32>,
+    // ack_receiver: Receiver<u32>,
+) -> io::Result<Child> {
+    unsafe {
+        Command::new(&command[0])
+            .args(&command[1..])
+            .stdout(pid_pipe)
+            //pre_exec is blocking!
+            .pre_exec(move || work_load())
+            .spawn()
+    }
+}
+fn work_load(// command: Vec<String>,
+    //pid_sender: SyncSender<u32>,
+    // ack_receiver: Receiver<u32>,
+) -> io::Result<()> {
+    io::stdout()
+        .write_all(&std::process::id().to_ne_bytes())
+        .expect("Failed to write to pipe");
+    //original attempt to send mpsc and then execvp. Of course execvp just takes over the process, would need to pair it with fork. And mpsc doesn't seem to communicate between processes
+
+    // pid_sender
+    //    .send(std::process::id())
+    //   .expect("interthread communication failure");
+    // if ack_receiver
+    //     .recv()
+    //     .expect("Failed interthread communication")
+    //     == 0
+    {
+        // let c_s = std::ffi::CString::new(command[0].as_str()).unwrap();
+        // let f_ptr = c_s.as_bytes().as_ptr() as *const i8;
+        // let a_s: Vec<_> = command[1..]
+        //     .iter()
+        //     .map(|arg| std::ffi::CString::new(arg.as_str()).unwrap())
+        //     .collect();
+        // let mut a_ptr: Vec<_> = a_s.iter().map(|arg| arg.as_ptr()).collect();
+        // a_ptr.push(std::ptr::null());
+        // let p: *const *const std::os::raw::c_char = a_ptr.as_ptr();
+        // unsafe { libc::execvp(f_ptr, p) };
+
+        //sometimes I just need to waste some time
+        // let mut sum = 0;
+        // for i in 0..1000000 {
+        //     if i % 2 == 0 {
+        //         sum += i;
+        //     } else {
+        //         sum -= i;
+        //     }
+        // }
+        // println!("Sum {}\n", sum);
+    }
+    // std::thread::sleep(std::time::Duration::from_millis(10000));
+    Ok(())
+}
 /// Run perf stat on the given command and event combinations. Currently starts and stops a cycles timer in serial for each event specified.
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
@@ -58,25 +127,44 @@ pub fn run_stat(options: &StatOptions) {
     }
 
     let mut event_list: Vec<EventCounter> = Vec::new();
-    let mut child = Command::new(&options.command[0])
-        .args(&options.command[1..])
-        .spawn()
-        .unwrap();
-    //prevent race condition on child program run time on most programs
-    unsafe { kill(child.id() as i32, libc::SIGSTOP) };
+    //mpsc route didn't work, they don't seem to communicate across processes
+    let (pid_sender, pid_receiver) = sync_channel::<u32>(0);
+    let (ack_sender, ack_receiver) = sync_channel::<u32>(0);
+
+    //this pipe attempt aso not working, no support for reading from child that I can find
+    let pid_pipe = Stdio::piped();
+    println!("My id: {}\n", std::process::id());
+    let mut child = create_launch_thread(options.command.clone(), pid_pipe);
+
+    let mut pid_arr: [u8; std::mem::size_of::<u32>()];
+    let pid_child = pid_pipe.read_exact(&pid_arr); // pid_receiver
+                                                   // .recv()
+                                                   // .expect("Failed interthread communication");
+    println!("My id: {}, Spawned Id {}\n", std::process::id(), pid_child);
+
     for event in &options.event {
-        let e = Event::new(*event, Some(&child));
-        let start = e.start_counter().unwrap();
         event_list.push(EventCounter {
-            event: e,
-            start: start,
+            event: Event::new(*event, Some(pid_child)),
+            start: 0,
             stop: 0,
         });
     }
-    unsafe { kill(child.id() as i32, libc::SIGCONT) };
+    println!("Events Initialized\n");
+    // ack_sender
+    //     .send(0)
+    //     .expect("Failed interthread communication");
+    for e in event_list.iter_mut() {
+        e.start = e.event.start_counter().unwrap();
+    }
+    println!("Counters Started, waiting for child completion\n");
 
-    //create another process from command
-    child.wait().expect("Failed to execute process");
+    //wait for thread and process
+    child
+        .join()
+        .expect("Failed to wait for thread")
+        .expect("Failed to wait for process")
+        .wait()
+        .expect("Faild to wait for process\n");
 
     for e in event_list.iter_mut() {
         e.stop = e.event.stop_counter().unwrap();

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -41,33 +41,36 @@ pub struct StatOptions {
 pub fn run_stat(options: &StatOptions) {
     //demonstrating from cli. In future rather than starting and stopping counter in series for each event, events will have the ability to be added in groups that will coordinate their timing.
 
-    for event in &options.event {
-        let e = Event::new(*event);
-        let cnt: isize = e.start_counter().unwrap();
+    for command in &options.command {
 
-        //create another process from command
-        let output = Command::new(options.command.get(0).unwrap())
-            .output()
-            .expect("failed to execute process");
+        for event in &options.event {
+            let e = Event::new(*event);
+            let cnt: isize = e.start_counter().unwrap();
 
-        let final_cnt = e.stop_counter().unwrap();
-        let total_cnt = final_cnt - cnt;
+            //create another process from command
+            let output = Command::new(command)
+                .output()
+                .expect("failed to execute process");
 
-        // Create buffer variable
-        let buf = &output.stdout;
+            let final_cnt = e.stop_counter().unwrap();
+            let total_cnt = final_cnt - cnt;
 
-        // Convert &vec[u8] into string
-        let s = match str::from_utf8(buf) {
-            Ok(v) => v,
-            Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-        };
+            // Create buffer variable
+            let buf = &output.stdout;
 
-        //output command's output
-        println!(
-            "{}\nPerformance counter stats for '{}'\n",
-            s.to_string(),
-            options.command.get(0).unwrap()
-        );
-        println!(" Number of cycles: {}\n", total_cnt);
+            // Convert &vec[u8] into string
+            let s = match str::from_utf8(buf) {
+                Ok(v) => v,
+                Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+            };
+
+            //output command's output
+            println!(
+                "{}\nPerformance counter stats for '{}'\n",
+                s.to_string(),
+                options.command.get(0).unwrap()
+            );
+            println!(" Number of cycles: {}\n", total_cnt);
+        }
     }
 }


### PR DESCRIPTION
Run with: `perf stat -e cycles -e instructions ls -a` or your program of choice. 
Addresses race condition using fork and pipes as suggested by Bart Massey. Makes pid specification optional so None can be passed, in which case default of '0' is assigned. Confirmed by fixing tests so they pass None. Uses `std::process::Command` and `CommandExt` for control of command set up and execution and `libc::fork`/`open_pipe::pipes` to set up child process and control communication between parent and child.