### PR TITLE
Cache Events

### DIFF
--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -10,6 +10,8 @@ use crate::event::fd;
 use crate::event::utils::*;
 use crate::stat::StatEvent;
 
+const PERF_EVENT_ATTR_SIZE: u32 = std::mem::size_of::<perf_event_attr>() as u32;
+
 ///Event enum contains file descriptor and event type
 //simple starting options. Add more as needed
 pub struct Event {
@@ -20,11 +22,16 @@ pub struct Event {
 /// Initialize perf attributes. Currently set up to match on intended event.
 /// Returns the initialized perf_event_attr data structure or an error.
 pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
+    // To measure hardware CPU cache events
+    // when `type_` is set to `PERF_TYPE_HW_CACHE`
+    // the value of config must be computed.
+    // See the `perf_event_open()` man page for details.
+    let cache_config = |id, op, rs| (id as u64) | ((op as u64) << 8) | ((rs as u64) << 16);
     match &event {
         StatEvent::Cycles => {
             let event_open = &mut perf_event_attr {
                 type_: perf_type_id_PERF_TYPE_HARDWARE,
-                size: std::mem::size_of::<perf_event_attr>() as u32,
+                size: PERF_EVENT_ATTR_SIZE,
                 config: perf_hw_id_PERF_COUNT_HW_CPU_CYCLES as u64,
                 ..Default::default()
             };
@@ -36,7 +43,7 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
         StatEvent::Instructions => {
             let event_open = &mut perf_event_attr {
                 type_: perf_type_id_PERF_TYPE_HARDWARE,
-                size: std::mem::size_of::<perf_event_attr>() as u32,
+                size: PERF_EVENT_ATTR_SIZE,
                 config: perf_hw_id_PERF_COUNT_HW_INSTRUCTIONS as u64,
                 ..Default::default()
             };
@@ -45,11 +52,24 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_hv(1);
             Ok(*event_open)
         }
+<<<<<<< HEAD
         StatEvent::TaskClock => {
             let event_open = &mut perf_event_attr {
                 type_: perf_type_id_PERF_TYPE_SOFTWARE,
                 size: std::mem::size_of::<perf_event_attr>() as u32,
                 config: perf_sw_ids_PERF_COUNT_SW_TASK_CLOCK as u64,
+=======
+        StatEvent::L1DCacheRead => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1D,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_READ,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_ACCESS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+>>>>>>> Feat: added cache events
                 ..Default::default()
             };
             event_open.set_disabled(1);
@@ -57,6 +77,7 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_hv(1);
             Ok(*event_open)
         }
+<<<<<<< HEAD
         StatEvent::ContextSwitches => {
             let event_open = &mut perf_event_attr {
                 type_: perf_type_id_PERF_TYPE_SOFTWARE,
@@ -70,6 +91,94 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             Ok(*event_open)
         }
         _ => Err(EventErr::InvalidEvent),
+=======
+        StatEvent::L1DCacheWrite => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1D,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_WRITE,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_ACCESS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        StatEvent::L1DCacheReadMiss => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1D,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_READ,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_MISS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        StatEvent::L1DCacheWriteMiss => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1D,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_WRITE,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_MISS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        StatEvent::L1ICacheRead => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1I,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_READ,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_ACCESS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        StatEvent::L1ICacheReadMiss => {
+            let config: u64 = cache_config(
+                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1I,
+                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_READ,
+                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_MISS,
+            );
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_HW_CACHE,
+                size: PERF_EVENT_ATTR_SIZE,
+                config,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        _ => Err(EventErr::InvalidEvent)
+>>>>>>> Feat: added cache events
     }
 }
 
@@ -91,6 +200,14 @@ impl Event {
     pub fn stop_counter(&self) -> Result<isize, SysErr> {
         match self.fd.disable() {
             Ok(_) => self.fd.read(),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Reset the counter to 0.
+    pub fn reset_counter(&self) -> Result<(), SysErr> {
+        match self.fd.reset() {
+            Ok(_) => Ok(()),
             Err(e) => Err(e),
         }
     }
@@ -120,8 +237,13 @@ fn inst_open_test() {
 }
 
 #[test]
+<<<<<<< HEAD
 fn taskclock_open_test() {
     let event = Event::new(StatEvent::TaskClock, None);
+=======
+fn l1_data_cache_read_open_test() {
+    let event = Event::new(StatEvent::L1DCacheRead, None);
+>>>>>>> Feat: added cache events
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, 0);
     assert_ne!(cnt, -1);
@@ -131,10 +253,65 @@ fn taskclock_open_test() {
 }
 
 #[test]
+<<<<<<< HEAD
 fn cs_open_test() {
     let event = Event::new(StatEvent::ContextSwitches, None);
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, -1);
     let cnt_2 = event.stop_counter().unwrap();
     assert_ne!(cnt_2, -1);
+=======
+fn l1_data_cache_write_open_test() {
+    let event = Event::new(StatEvent::L1DCacheWrite, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn l1_data_cache_read_miss_open_test() {
+    let event = Event::new(StatEvent::L1DCacheReadMiss, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn l1_data_cache_write_miss_open_test() {
+    let event = Event::new(StatEvent::L1DCacheWriteMiss, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn l1_inst_cache_read_open_test() {
+    let event = Event::new(StatEvent::L1ICacheRead, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn l1_inst_cache_read_miss_open_test() {
+    let event = Event::new(StatEvent::L1ICacheReadMiss, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+>>>>>>> Feat: added cache events
 }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -126,40 +126,6 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_hv(1);
             Ok(*event_open)
         }
-        StatEvent::L1DCacheWriteMiss => {
-            let config: u64 = cache_config(
-                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1D,
-                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_WRITE,
-                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_MISS,
-            );
-            let event_open = &mut perf_event_attr {
-                type_: perf_type_id_PERF_TYPE_HW_CACHE,
-                size: PERF_EVENT_ATTR_SIZE,
-                config,
-                ..Default::default()
-            };
-            event_open.set_disabled(1);
-            event_open.set_exclude_kernel(1);
-            event_open.set_exclude_hv(1);
-            Ok(*event_open)
-        }
-        StatEvent::L1ICacheRead => {
-            let config: u64 = cache_config(
-                perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1I,
-                perf_hw_cache_op_id_PERF_COUNT_HW_CACHE_OP_READ,
-                perf_hw_cache_op_result_id_PERF_COUNT_HW_CACHE_RESULT_ACCESS,
-            );
-            let event_open = &mut perf_event_attr {
-                type_: perf_type_id_PERF_TYPE_HW_CACHE,
-                size: PERF_EVENT_ATTR_SIZE,
-                config,
-                ..Default::default()
-            };
-            event_open.set_disabled(1);
-            event_open.set_exclude_kernel(1);
-            event_open.set_exclude_hv(1);
-            Ok(*event_open)
-        }
         StatEvent::L1ICacheReadMiss => {
             let config: u64 = cache_config(
                 perf_hw_cache_id_PERF_COUNT_HW_CACHE_L1I,
@@ -274,28 +240,6 @@ fn l1_data_cache_write_open_test() {
 #[test]
 fn l1_data_cache_read_miss_open_test() {
     let event = Event::new(StatEvent::L1DCacheReadMiss, None);
-    let cnt: isize = event.start_counter().unwrap();
-    assert_ne!(cnt, 0);
-    assert_ne!(cnt, -1);
-    let cnt_2 = event.stop_counter().unwrap();
-    assert_ne!(cnt, cnt_2);
-    assert!(cnt < cnt_2);
-}
-
-#[test]
-fn l1_data_cache_write_miss_open_test() {
-    let event = Event::new(StatEvent::L1DCacheWriteMiss, None);
-    let cnt: isize = event.start_counter().unwrap();
-    assert_ne!(cnt, 0);
-    assert_ne!(cnt, -1);
-    let cnt_2 = event.stop_counter().unwrap();
-    assert_ne!(cnt, cnt_2);
-    assert!(cnt < cnt_2);
-}
-
-#[test]
-fn l1_inst_cache_read_open_test() {
-    let event = Event::new(StatEvent::L1ICacheRead, None);
     let cnt: isize = event.start_counter().unwrap();
     assert_ne!(cnt, 0);
     assert_ne!(cnt, -1);

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -18,8 +18,17 @@ use structopt::StructOpt;
 pub enum StatEvent {
     Cycles,
     Instructions,
+<<<<<<< HEAD
     TaskClock,
     ContextSwitches,
+=======
+    L1DCacheRead,
+    L1DCacheWrite,
+    L1DCacheReadMiss,
+    L1DCacheWriteMiss,
+    L1ICacheRead,
+    L1ICacheReadMiss,
+>>>>>>> Feat: added cache events
 }
 
 /// Match on each supported event to parse from command line
@@ -29,8 +38,17 @@ impl FromStr for StatEvent {
         match s {
             "cycles" => Ok(StatEvent::Cycles),
             "instructions" => Ok(StatEvent::Instructions),
+<<<<<<< HEAD
             "task-clock" => Ok(StatEvent::TaskClock),
             "context-switches" => Ok(StatEvent::ContextSwitches),
+=======
+            "L1D-cache-reads" => Ok(StatEvent::L1DCacheRead),
+            "L1D-cache-writes" => Ok(StatEvent::L1DCacheWrite),
+            "L1D-cache-read-misses" => Ok(StatEvent::L1DCacheReadMiss),
+            "L1D-cache-write-misses" => Ok(StatEvent::L1DCacheWriteMiss),
+            "L1I-cache-reads" => Ok(StatEvent::L1ICacheRead),
+            "L1I-cache-read-misses" => Ok(StatEvent::L1ICacheReadMiss),
+>>>>>>> Feat: added cache events
             _ => Err(ParseError::InvalidEvent),
         }
     }
@@ -43,8 +61,17 @@ impl ToString for StatEvent {
         match self {
             StatEvent::Cycles => "cycles".to_string(),
             StatEvent::Instructions => "instructions".to_string(),
+<<<<<<< HEAD
             StatEvent::TaskClock => "task clock".to_string(),
             StatEvent::ContextSwitches => "context switches".to_string(),
+=======
+            StatEvent::L1DCacheRead => "L1D-cache-reads".to_string(),
+            StatEvent::L1DCacheWrite => "L1D-cache-writes".to_string(),
+            StatEvent::L1DCacheReadMiss => "L1D-cache-read-misses".to_string(),
+            StatEvent::L1DCacheWriteMiss => "L1D-cache-write-misses".to_string(),
+            StatEvent::L1ICacheRead => "L1I-cache-reads".to_string(),
+            StatEvent::L1ICacheReadMiss => "L1I-cache-read-misses".to_string(),
+>>>>>>> Feat: added cache events
         }
     }
 }

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -25,8 +25,6 @@ pub enum StatEvent {
     L1DCacheRead,
     L1DCacheWrite,
     L1DCacheReadMiss,
-    L1DCacheWriteMiss,
-    L1ICacheRead,
     L1ICacheReadMiss,
 >>>>>>> Feat: added cache events
 }
@@ -45,8 +43,6 @@ impl FromStr for StatEvent {
             "L1D-cache-reads" => Ok(StatEvent::L1DCacheRead),
             "L1D-cache-writes" => Ok(StatEvent::L1DCacheWrite),
             "L1D-cache-read-misses" => Ok(StatEvent::L1DCacheReadMiss),
-            "L1D-cache-write-misses" => Ok(StatEvent::L1DCacheWriteMiss),
-            "L1I-cache-reads" => Ok(StatEvent::L1ICacheRead),
             "L1I-cache-read-misses" => Ok(StatEvent::L1ICacheReadMiss),
 >>>>>>> Feat: added cache events
             _ => Err(ParseError::InvalidEvent),
@@ -68,8 +64,6 @@ impl ToString for StatEvent {
             StatEvent::L1DCacheRead => "L1D-cache-reads".to_string(),
             StatEvent::L1DCacheWrite => "L1D-cache-writes".to_string(),
             StatEvent::L1DCacheReadMiss => "L1D-cache-read-misses".to_string(),
-            StatEvent::L1DCacheWriteMiss => "L1D-cache-write-misses".to_string(),
-            StatEvent::L1ICacheRead => "L1I-cache-reads".to_string(),
             StatEvent::L1ICacheReadMiss => "L1I-cache-read-misses".to_string(),
 >>>>>>> Feat: added cache events
         }


### PR DESCRIPTION
I added support for L1D cache read/writes and L1I cache reads (can only read from instruction cache). I also plan on adding support for the TLB, since that also has a high frequency of use. It is important to note that currently, `l1_inst_cache_read_open_test()` fails due to a panic when creating the file descriptor. I am not sure why, and figured it should be included in case anyone wants to take a crack at it. Also note that test failure is possible if the caches are never actually accessed (they might not have to be), or their accesses don't miss. 

- [x]  `cargo test`
- [x] `cargo fmt`
- [ ] `cargo clippy`

