### PR TITLE
Fix: basic GuiOptions struct to fix --help message

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -32,7 +32,7 @@ enum Gui {
     Loaded(State),
 }
 
-/// Configuration settings for running test
+/// Configuration settings for running the GUI
 #[derive(Debug, StructOpt)]
 pub struct GuiOptions {}
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,6 +7,9 @@ use iced::{
     Align, Application, Clipboard, Command, Element, Length, Settings,
 };
 
+extern crate structopt;
+use structopt::StructOpt;
+
 mod pane_content;
 mod perf_event;
 mod save_state;
@@ -19,7 +22,7 @@ use save_state::*;
 use state::*;
 
 /// Run the Gui Launcher
-pub fn run_gui() -> iced::Result {
+pub fn run_gui(options: &GuiOptions) -> iced::Result {
     Gui::run(Settings::default())
 }
 
@@ -28,6 +31,10 @@ enum Gui {
     Loading,
     Loaded(State),
 }
+
+/// Configuration settings for running test
+#[derive(Debug, StructOpt)]
+pub struct GuiOptions {}
 
 /// Messages to be sent to the parent widget from
 /// other child widgets, and consumed on update

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ enum Opt {
         name = "gui",
         about = "Launches gui"
     )]
-    Gui(TestOptions),
+    Gui(GuiOptions),
 }
 
 fn main() {
@@ -54,7 +54,7 @@ fn main() {
         Opt::Stat(x) => run_stat(&x),
         Opt::Test(x) => run_test(&x),
         Opt::Gui(x) => {
-            run_gui().unwrap();
+            run_gui(&x).unwrap();
         }
     }
 }


### PR DESCRIPTION
This _very_ simple PR is to fix the erroneous `--help` message when running `ruperf gui`. It passes along an empty GuiOptions struct which StructOpts uses to generate output messages. There's no options in the struct, but we can easily add them like we have in `test` and `stat` if we think of any good ones.