### PR TITLE
Fix: created sample program packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,9 @@ os_pipe = "0.9.2"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"
 directories-next = "2.0"
+
+[workspace]
+members = [
+	"samples/fp-calc",
+	"samples/file-io",
+]

--- a/samples/file-io/Cargo.toml
+++ b/samples/file-io/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "file-io"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+structopt = "0.3.21"

--- a/samples/file-io/src/main.rs
+++ b/samples/file-io/src/main.rs
@@ -1,5 +1,5 @@
-//! Sample program to run `ruperf stat` against. 
-//! Writes to and reads from a file. 
+//! Sample program to run `ruperf stat` against.
+//! Writes to and reads from a file.
 
 use std::env;
 use std::fs;

--- a/samples/fp-calc/Cargo.toml
+++ b/samples/fp-calc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fp-calc"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+structopt = "0.3.21"

--- a/samples/fp-calc/src/main.rs
+++ b/samples/fp-calc/src/main.rs
@@ -1,5 +1,5 @@
-//! Sample program to run `ruperf stat` against. 
-//! Performs some floating point computations. 
+//! Sample program to run `ruperf stat` against.
+//! Performs some floating point computations.
 
 use structopt::StructOpt;
 


### PR DESCRIPTION
This PR does two things:

- Creates two separate binary packages `fp-calc` and `file-io` that can be profiled by our tool.
- Creates a samples directory where future programs we wish to sample and profile may be put.

Note:

`cargo build` will not compile either of the packages in /samples. To compile these packages run `cargo build -p <package>` and the executable will be placed in `/target/debug`.