### PR TITLE
Feat: perf_event_paranoid check test, also more info with --json flag

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -10,6 +10,7 @@
 //! </ul>
 
 mod basic;
+mod paranoid;
 mod pfm;
 mod testutils;
 
@@ -90,7 +91,7 @@ pub fn run_test(options: &TestOptions) {
         return;
     }
     let settings = RunSettings {
-        verbose: options.verbose,
+        verbose: options.verbose || options.json,
         json: options.json,
     };
     if !options.to_run.is_empty() {

--- a/src/test/paranoid.rs
+++ b/src/test/paranoid.rs
@@ -1,6 +1,8 @@
-//!
-//!
-//!
+//! This test checks the value of the linux
+//! /proc/sys/kernel/perf_event_paranoid flag and will pass if the
+//! value in the file is 0 or less. Some counts from perf_event_open
+//! require this flag to be 0 or less, so this test will read the value
+//! value from it and check.
 
 use crate::test::RunSettings;
 use crate::test::Test;
@@ -8,10 +10,10 @@ use crate::test::TestResult;
 use std::fs;
 use std::path::Path;
 
-// TEST: Check for presence of libpfm4
+// TEST: Check the value of /proc/sys/kernel/perf_event_paranoid flag is 0 or less
 pub fn test_check_paranoid_flag() -> Test {
-    // This uses the linux command "ldconfig" and returns
-    // based on whether or not the output contains "libpfm."
+    // This test checks the value of /proc/sys/kernel/perf_event_paranoid
+    // and passes if it is equal to 0 or less.
     fn check_paranoid_flag(settings: &RunSettings) -> TestResult {
         let paranoid_flag = "/proc/sys/kernel/perf_event_paranoid".to_string();
         let paranoid_flag_path = Path::new(&paranoid_flag);

--- a/src/test/paranoid.rs
+++ b/src/test/paranoid.rs
@@ -1,0 +1,47 @@
+//!
+//!
+//!
+
+use crate::test::RunSettings;
+use crate::test::Test;
+use crate::test::TestResult;
+use std::fs;
+use std::path::Path;
+
+// TEST: Check for presence of libpfm4
+pub fn test_check_paranoid_flag() -> Test {
+    // This uses the linux command "ldconfig" and returns
+    // based on whether or not the output contains "libpfm."
+    fn check_paranoid_flag(settings: &RunSettings) -> TestResult {
+        let paranoid_flag = "/proc/sys/kernel/perf_event_paranoid".to_string();
+        let paranoid_flag_path = Path::new(&paranoid_flag);
+        if !paranoid_flag_path.exists() {
+            if settings.verbose {
+                return TestResult::Failed(format!("\nINFO: Couldn't find {}", paranoid_flag));
+            }
+            return TestResult::Failed("(1)".to_string());
+        }
+        let contents = fs::read_to_string(paranoid_flag_path).unwrap();
+        let value = contents.trim_end().parse::<i32>().unwrap();
+        match value {
+            x if x <= 0 => TestResult::Passed,
+            x => {
+                if settings.verbose {
+                    return TestResult::Failed(format!(
+                        "\nINFO:\tExpected 0 but instead flag was {}",
+                        x
+                    ));
+                }
+                TestResult::Failed("(1)".to_string())
+            }
+        }
+    }
+
+    Test {
+        name: "paranoid_flag_check".to_string(),
+        description: "Checks that perf_event_paranoid flag is <= 0".to_string(),
+        call: check_paranoid_flag,
+        subtests: Vec::new(),
+        is_subtest: false,
+    }
+}

--- a/src/test/testutils.rs
+++ b/src/test/testutils.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::test::basic;
+use crate::test::paranoid;
 use crate::test::pfm;
 use crate::test::RunSettings;
 use crate::test::Test;
@@ -20,6 +21,7 @@ pub fn make_tests() -> Vec<Test> {
         basic::test_passes_after_1sec(),
         basic::test_with_pointless_subtests(),
         pfm::test_check_for_libpfm4(),
+        paranoid::test_check_paranoid_flag(),
     ];
     tests
 }
@@ -30,11 +32,12 @@ pub fn run_all_tests(tests: &[Test], to_skip: &[String], settings: &RunSettings)
     let mut tests_passed = 0;
     let mut tests_failed = 0;
     let mut tests_skipped = 0;
+    let mut additional_info: Vec<String> = Vec::new();
     let mut results_as_json: Vec<serde_json::Value> = Vec::new();
     if settings.json {}
     for (index, test) in tests.iter().enumerate() {
         should_skip = to_skip.iter().any(|i| *i == index.to_string());
-        let result = run_single_test(&test, index, should_skip, "".to_string(), &settings);
+        let result = run_single_test(test, index, should_skip, "".to_string(), settings);
         if settings.json {
             let result_string: String;
             match result {
@@ -42,7 +45,10 @@ pub fn run_all_tests(tests: &[Test], to_skip: &[String], settings: &RunSettings)
                     tests_passed += 1;
                     result_string = String::from("passed");
                 }
-                TestResult::Failed(_) => {
+                TestResult::Failed(info) => {
+                    if !info.is_empty() {
+                        additional_info.push(info);
+                    }
                     tests_failed += 1;
                     result_string = String::from("failed");
                 }
@@ -55,7 +61,8 @@ pub fn run_all_tests(tests: &[Test], to_skip: &[String], settings: &RunSettings)
                 "name": test.name,
                 "description": test.description,
                 "result": result_string,
-                "number": index as u32
+                "number": index as u32,
+                "additional_info": additional_info
             }));
         }
     }
@@ -91,7 +98,7 @@ pub fn run_single_test(
     if should_skip {
         result_type = TestResult::Skipped;
     } else if test.subtests.is_empty() {
-        result_type = (test.call)(&settings);
+        result_type = (test.call)(settings);
     } else {
         if !settings.json {
             println!();


### PR DESCRIPTION
I added a test that checks `/proc/sys/kernel/perf_event_paranoid` and passes if the value is 0 or less.

I also added the additional information from `--verbose` to the `--json` output, and did some various things clippy told me to do.