### PR TITLE
Fix: command passed to `stat` is now required

### DIFF
--- a/src/stat.rs
+++ b/src/stat.rs
@@ -49,7 +49,7 @@ pub struct StatOptions {
 
     // Allows multiple arguments to be passed, collects everything remaining on
     // the command line
-    #[structopt(required = false, help = "Command to run")]
+    #[structopt(required = true, help = "Command to run")]
     pub command: Vec<String>,
 }
 


### PR DESCRIPTION
As we discussed in the meeting, we will have `stat` require a command to measure. In the future we could have it measure all commands like the real `perf stat`, but it would take a bit of work. With this change it won't panic anymore.