### PR TITLE
Documentation: Add copyright notice to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+Copyright (&copy;) Timothy Maloney 2021
+Copyright (&copy;) Briana Oursler 2021
+Copyright (&copy;) Greg Hairfield 2021
+Copyright (&copy;) Sam Little 2021
+Copyright (&copy;) Michael Scherrer 2021
+
 ### GNU GENERAL PUBLIC LICENSE
 
 Version 2, June 1991


### PR DESCRIPTION
Add names of project members to copyright notice on license file. Match order
articulated on README.
