### PR TITLE
Context switches and task clock

### DIFF
--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -45,6 +45,30 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_hv(1);
             Ok(*event_open)
         }
+        StatEvent::TaskClock => {
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_SOFTWARE,
+                size: std::mem::size_of::<perf_event_attr>() as u32,
+                config: perf_sw_ids_PERF_COUNT_SW_TASK_CLOCK as u64,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(1);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
+        StatEvent::ContextSwitches => {
+            let event_open = &mut perf_event_attr {
+                type_: perf_type_id_PERF_TYPE_SOFTWARE,
+                size: std::mem::size_of::<perf_event_attr>() as u32,
+                config: perf_sw_ids_PERF_COUNT_SW_CONTEXT_SWITCHES as u64,
+                ..Default::default()
+            };
+            event_open.set_disabled(1);
+            event_open.set_exclude_kernel(0);
+            event_open.set_exclude_hv(1);
+            Ok(*event_open)
+        }
         _ => Err(EventErr::InvalidEvent),
     }
 }

--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -118,3 +118,23 @@ fn inst_open_test() {
     assert_ne!(cnt, cnt_2);
     assert!(cnt < cnt_2);
 }
+
+#[test]
+fn taskclock_open_test() {
+    let event = Event::new(StatEvent::TaskClock, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, 0);
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt, cnt_2);
+    assert!(cnt < cnt_2);
+}
+
+#[test]
+fn cs_open_test() {
+    let event = Event::new(StatEvent::ContextSwitches, None);
+    let cnt: isize = event.start_counter().unwrap();
+    assert_ne!(cnt, -1);
+    let cnt_2 = event.stop_counter().unwrap();
+    assert_ne!(cnt_2, -1);
+}

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -49,7 +49,11 @@ impl ToString for StatEvent {
     }
 }
 
-/// Configuration settings for running stat. A program to profile is a required argument. Default events will run on that program if no events are specified. Specify events using the flag `-e or --event`. See `./ruperf stat --help' for more information.
+/// Configuration settings for running stat. A program to profile is a required
+/// argument. Default events will run on that program if no events are
+/// specified. Specify events using the flag `-e or --event`. See `./ruperf stat
+/// --help' for more information.
+
 #[derive(Debug, StructOpt)]
 pub struct StatOptions {
     #[structopt(short, long, help = "Event to collect", number_of_values = 1)]


### PR DESCRIPTION
Add support for context switch and task clock software events. Check fd opens with basic test.