### PR TITLE
Chore: added rustdoc comments to files in `test`

### DIFF
--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -1,6 +1,6 @@
-//!
-//!
-//!
+//! `basic.rs` contains basic tests used to demonstrate the use
+//! of `ruperf test`. These tests don't do much other than provide
+//! a basic example of how the test program works.
 
 use crate::test::RunSettings;
 use crate::test::Test;

--- a/src/test/paranoid.rs
+++ b/src/test/paranoid.rs
@@ -1,5 +1,5 @@
-//! This test checks the value of the linux
-//! /proc/sys/kernel/perf_event_paranoid flag and will pass if the
+//! The test in `paranoid.rs` checks the value of the linux
+//! `/proc/sys/kernel/perf_event_paranoid` flag and will pass if the
 //! value in the file is 0 or less. Some counts from perf_event_open
 //! require this flag to be 0 or less, so this test will read the value
 //! value from it and check.
@@ -34,7 +34,7 @@ pub fn test_check_paranoid_flag() -> Test {
                         x
                     ));
                 }
-                TestResult::Failed("(1)".to_string())
+                TestResult::Failed(format!("({})", x))
             }
         }
     }

--- a/src/test/pfm.rs
+++ b/src/test/pfm.rs
@@ -1,6 +1,9 @@
-//!
-//!
-//!
+//! The test in `pfm.rs` checks for the presence of the library
+//! `libpfm4`, which will be required for future features of
+//! ruperf. It uses `ldconfig` to determine whether the library
+//! present on the machine or not. This test structure could
+//! be used to verify the presence of any library that can be
+//! seen by `ldconfig`.
 
 use crate::test::RunSettings;
 use crate::test::Test;

--- a/src/test/testutils.rs
+++ b/src/test/testutils.rs
@@ -1,6 +1,8 @@
-//!
-//!
-//!
+//! `testutils.rs` provides utility functions used for the
+//! test program. It provides a function that makes a list
+//! of the tests from this directory, as well as a function
+//! that runs all the tests in this directory and collects
+//! the results.
 
 use crate::test::basic;
 use crate::test::paranoid;


### PR DESCRIPTION
This is a really small PR that adds rustdoc comments to the top of files in `test` (they weren't there before)