### PR TITLE
Fix: `--json` additional info from `-v` is cleared

### DIFF
--- a/src/test/testutils.rs
+++ b/src/test/testutils.rs
@@ -32,10 +32,11 @@ pub fn run_all_tests(tests: &[Test], to_skip: &[String], settings: &RunSettings)
     let mut tests_passed = 0;
     let mut tests_failed = 0;
     let mut tests_skipped = 0;
-    let mut additional_info: Vec<String> = Vec::new();
+    let mut additional_info: Vec<String>;
     let mut results_as_json: Vec<serde_json::Value> = Vec::new();
     if settings.json {}
     for (index, test) in tests.iter().enumerate() {
+        additional_info = Vec::new();
         should_skip = to_skip.iter().any(|i| *i == index.to_string());
         let result = run_single_test(test, index, should_skip, "".to_string(), settings);
         if settings.json {


### PR DESCRIPTION
Sorry about all the PRs. This one is a super simple but necessary bugfix I found for the `--json` flag where the additional info wasn't being cleared if empty for each new test that was ran. Now it is cleared each test, so empty additional info doesn't re-use the last non-empty one.