### PR TITLE
Style: address clippy warns.

### DIFF
--- a/src/event/open.rs
+++ b/src/event/open.rs
@@ -144,7 +144,6 @@ pub fn event_open(event: &StatEvent) -> Result<perf_event_attr, EventErr> {
             event_open.set_exclude_hv(1);
             Ok(*event_open)
         }
-        _ => Err(EventErr::InvalidEvent),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ mod test;
 mod utils;
 
 extern crate structopt;
-use event::*;
 use gui::*;
 use stat::*;
 use structopt::StructOpt;


### PR DESCRIPTION
As discussed, ruperf should have no clippy or build warns. This address warns in main and stat modules.