### PR TITLE
Fix: removed unneeded `use` statement

### DIFF
--- a/src/test/counts.rs
+++ b/src/test/counts.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
 use std::io::Write;
-use std::time::Instant;
 
 use crate::event::open::Event;
 use crate::stat::launch_command_process;


### PR DESCRIPTION
Forgot to remove this on my previous PR, sorry. It was making clippy unhappy so it must be removed.